### PR TITLE
Update org references from seantallen-org to ponylang

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Generate documentation
         run: /entrypoint.py
         env:
-          INPUT_SITE_URL: "https://seantallen-org.github.io/msgpack/"
+          INPUT_SITE_URL: "https://ponylang.github.io/msgpack/"
           INPUT_LIBRARY_NAME: "msgpack"
           INPUT_DOCS_BUILD_DIR: "build/msgpack-docs"
       - name: Setup Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Generate documentation
         run: /entrypoint.py
         env:
-          INPUT_SITE_URL: "https://seantallen-org.github.io/msgpack/"
+          INPUT_SITE_URL: "https://ponylang.github.io/msgpack/"
           INPUT_LIBRARY_NAME: "msgpack"
           INPUT_DOCS_BUILD_DIR: "build/msgpack-docs"
       - name: Setup Pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,21 +17,21 @@ All notable changes this project will be documented in this file. This project a
 
 ### Added
 
-- Add decoding size limits to streaming decoder ([PR #71](https://github.com/seantallen-org/msgpack/pull/71))
-- Add container depth limits to streaming decoder ([PR #72](https://github.com/seantallen-org/msgpack/pull/72))
-- Add skip method for advancing past values without decoding ([PR #73](https://github.com/seantallen-org/msgpack/pull/73))
-- Add opt-in UTF-8 validation for str format values ([PR #76](https://github.com/seantallen-org/msgpack/pull/76))
+- Add decoding size limits to streaming decoder ([PR #71](https://github.com/ponylang/msgpack/pull/71))
+- Add container depth limits to streaming decoder ([PR #72](https://github.com/ponylang/msgpack/pull/72))
+- Add skip method for advancing past values without decoding ([PR #73](https://github.com/ponylang/msgpack/pull/73))
+- Add opt-in UTF-8 validation for str format values ([PR #76](https://github.com/ponylang/msgpack/pull/76))
 
 ## [0.3.0] - 2026-02-08
 
 ### Added
 
-- Add streaming-safe MessagePack decoder ([PR #52](https://github.com/seantallen-org/msgpack/pull/52))
-- Add compact encoding and decoding methods ([PR #60](https://github.com/seantallen-org/msgpack/pull/60))
+- Add streaming-safe MessagePack decoder ([PR #52](https://github.com/ponylang/msgpack/pull/52))
+- Add compact encoding and decoding methods ([PR #60](https://github.com/ponylang/msgpack/pull/60))
 
 ### Changed
 
-- Change timestamp nsec type from I64 to U32 ([PR #56](https://github.com/seantallen-org/msgpack/pull/56))
+- Change timestamp nsec type from I64 to U32 ([PR #56](https://github.com/ponylang/msgpack/pull/56))
 
 ## [0.2.5] - 2022-02-26
 
@@ -39,7 +39,7 @@ All notable changes this project will be documented in this file. This project a
 
 ### Fixed
 
-- Update to work with Pony 0.49.0 ([PR #41](https://github.com/seantallen-org/msgpack/pull/41))
+- Update to work with Pony 0.49.0 ([PR #41](https://github.com/ponylang/msgpack/pull/41))
 
 ## [0.2.3] - 2019-09-02
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Internal helpers (`_FormatName`, `_Limit`, `_Size`) are private primitives prefi
 
 All fallible methods use `?` for error signaling.
 
-**Known limitation:** `MessagePackDecoder` is not suitable for streaming. It assumes all data is available when decoding begins. If you read the type byte but the full payload hasn't arrived yet, the stream and reader will be corrupted. See [issue #14](https://github.com/seantallen-org/msgpack/issues/14). `MessagePackStreamingDecoder` addresses this by peeking at format bytes and length fields before consuming any data — if insufficient data is available, it returns `NotEnoughData` with zero bytes consumed.
+**Known limitation:** `MessagePackDecoder` is not suitable for streaming. It assumes all data is available when decoding begins. If you read the type byte but the full payload hasn't arrived yet, the stream and reader will be corrupted. See [issue #14](https://github.com/ponylang/msgpack/issues/14). `MessagePackStreamingDecoder` addresses this by peeking at format bytes and length fields before consuming any data — if insufficient data is available, it returns `NotEnoughData` with zero bytes consumed.
 
 ## Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Additional notes regarding formatting:
 
 ## Bug report
 
-First of all please [search existing issues](https://github.com/seantallen-org/msgpack/issues) to make sure your issue hasn't already been reported. If you cannot find a suitable issue — [create a new one](https://github.com/seantallen-org/msgpack/issues/new).
+First of all please [search existing issues](https://github.com/ponylang/msgpack/issues) to make sure your issue hasn't already been reported. If you cannot find a suitable issue — [create a new one](https://github.com/ponylang/msgpack/issues/new).
 
 Provide the following details:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ msgpack is currently beta software. It provides compact encoding/decoding method
 ## Installation
 
 * Install [corral](https://github.com/ponylang/corral)
-* `corral add github.com/seantallen-org/msgpack.git --version 0.3.1`
+* `corral add github.com/ponylang/msgpack.git --version 0.3.1`
 * `corral fetch` to fetch your dependencies
 * `use "msgpack"` to include this package
 * `corral run -- ponyc` to compile your application
@@ -79,4 +79,4 @@ See the `examples/` directory for runnable demos.
 
 ## API Documentation
 
-[https://seantallen-org.github.io/msgpack/](https://seantallen-org.github.io/msgpack/)
+[https://ponylang.github.io/msgpack/](https://ponylang.github.io/msgpack/)

--- a/corral.json
+++ b/corral.json
@@ -5,9 +5,9 @@
   ],
   "info": {
     "description": "Pure Pony implementation of the MessagePack serialization format.",
-    "homepage": "https://github.com/seantallen-org/msgpack",
+    "homepage": "https://github.com/ponylang/msgpack",
     "license": "BSD-2-Clause",
-    "documentation_url": "https://seantallen-org.github.io/msgpack/",
+    "documentation_url": "https://ponylang.github.io/msgpack/",
     "version": "0.3.1",
     "name": "msgpack"
   }

--- a/msgpack/_unreachable.pony
+++ b/msgpack/_unreachable.pony
@@ -33,7 +33,7 @@ primitive _Unreachable
       @pony_os_stderr(),
       ("The unreachable was reached in %s at line %s\n"
         + "Please open an issue at "
-        + "https://github.com/seantallen-org/msgpack/"
+        + "https://github.com/ponylang/msgpack/"
         + "issues")
         .cstring(),
       loc.file().cstring(),


### PR DESCRIPTION
Update all `seantallen-org/msgpack` references to `ponylang/msgpack` after the repo transfer. Covers corral.json, README install command, GitHub Pages URLs in CI workflows, the `_Unreachable` issues URL, CONTRIBUTING issue links, CLAUDE.md, and CHANGELOG PR links.
