### PR TITLE
Fix all pony-lint errors

### DIFF
--- a/examples/decode-limits/decode_limits.pony
+++ b/examples/decode-limits/decode_limits.pony
@@ -1,0 +1,11 @@
+"""
+Demonstrates `MessagePackDecodeLimits` with the streaming
+decoder. When decoding data from untrusted sources, limits
+prevent denial-of-service attacks where a malicious payload
+claims enormous sizes for strings, binary data, or container
+counts.
+
+This example sets a tight `max_str_len` of 10 bytes, then
+shows that a short string decodes successfully while a longer
+string is rejected with `LimitExceeded`.
+"""

--- a/examples/decode-limits/main.pony
+++ b/examples/decode-limits/main.pony
@@ -4,17 +4,6 @@ use "../../msgpack"
 use "buffered"
 
 actor Main
-  """
-  Demonstrates `MessagePackDecodeLimits` with the streaming
-  decoder. When decoding data from untrusted sources, limits
-  prevent denial-of-service attacks where a malicious payload
-  claims enormous sizes for strings, binary data, or container
-  counts.
-
-  This example sets a tight `max_str_len` of 10 bytes, then
-  shows that a short string decodes successfully while a longer
-  string is rejected with `LimitExceeded`.
-  """
   new create(env: Env) =>
     try
       _decode_limits(env)?
@@ -23,8 +12,8 @@ actor Main
     end
 
   fun _decode_limits(env: Env) ? =>
-    let limits = MessagePackDecodeLimits(
-      where max_str_len' = 10)
+    let limits =
+      MessagePackDecodeLimits(where max_str_len' = 10)
     let sd = MessagePackStreamingDecoder(limits)
 
     // Encode a short string (5 bytes — within limit)

--- a/examples/encode-decode/encode_decode.pony
+++ b/examples/encode-decode/encode_decode.pony
@@ -1,0 +1,5 @@
+"""
+Demonstrates encoding and decoding MessagePack values using
+the compact API. Encodes nil, bool, uint, int, str, an array,
+and a map, then decodes each in the same order.
+"""

--- a/examples/encode-decode/main.pony
+++ b/examples/encode-decode/main.pony
@@ -4,11 +4,6 @@ use "../../msgpack"
 use "buffered"
 
 actor Main
-  """
-  Demonstrates encoding and decoding MessagePack values using
-  the compact API. Encodes nil, bool, uint, int, str, an array,
-  and a map, then decodes each in the same order.
-  """
   new create(env: Env) =>
     try
       _encode_and_decode(env)?
@@ -49,17 +44,17 @@ actor Main
     MessagePackDecoder.nil(r)?
     env.out.print("decoded nil")
 
-    env.out.print("decoded bool: "
-      + MessagePackDecoder.bool(r)?.string())
+    env.out.print("decoded bool: " +
+      MessagePackDecoder.bool(r)?.string())
 
-    env.out.print("decoded uint: "
-      + MessagePackDecoder.uint(r)?.string())
+    env.out.print("decoded uint: " +
+      MessagePackDecoder.uint(r)?.string())
 
-    env.out.print("decoded int: "
-      + MessagePackDecoder.int(r)?.string())
+    env.out.print("decoded int: " +
+      MessagePackDecoder.int(r)?.string())
 
-    env.out.print("decoded str: "
-      + MessagePackDecoder.str(r)?)
+    env.out.print("decoded str: " +
+      MessagePackDecoder.str(r)?)
 
     // Decode the array header, then each element
     let arr_size = MessagePackDecoder.array(r)?
@@ -78,7 +73,7 @@ actor Main
     while i < map_size do
       let key = MessagePackDecoder.str(r)?
       let value = MessagePackDecoder.uint(r)?
-      env.out.print("decoded map entry: "
-        + consume key + " = " + value.string())
+      env.out.print("decoded map entry: " +
+        (consume key) + " = " + value.string())
       i = i + 1
     end

--- a/examples/skip/main.pony
+++ b/examples/skip/main.pony
@@ -1,0 +1,52 @@
+// in your code this `use` statement would be:
+// use "msgpack"
+use "../../msgpack"
+use "buffered"
+
+actor Main
+  new create(env: Env) =>
+    try
+      _skip_unknown_fields(env)?
+    else
+      env.out.print("error during skip example")
+    end
+
+  fun _skip_unknown_fields(env: Env) ? =>
+    // Encode a map with 3 fields
+    let w: Writer ref = Writer
+    MessagePackEncoder.map(w, 3)
+    MessagePackEncoder.str(w, "name")?
+    MessagePackEncoder.str(w, "alice")?
+    MessagePackEncoder.str(w, "age")?
+    MessagePackEncoder.uint(w, 30)
+    MessagePackEncoder.str(w, "email")?
+    MessagePackEncoder.str(w, "a@b.c")?
+
+    // Transfer to reader
+    let r: Reader ref = Reader
+    for bs in w.done().values() do
+      r.append(bs)
+    end
+
+    // Decode the map, extracting only "name" and
+    // skipping everything else
+    let map_size = MessagePackDecoder.map(r)?
+    var name: (String | None) = None
+    var i: U32 = 0
+    while i < map_size do
+      let key = MessagePackDecoder.str(r)?
+      if (consume key) == "name" then
+        name = MessagePackDecoder.str(r)?
+      else
+        // Skip the value for any unrecognized key
+        MessagePackDecoder.skip(r)?
+      end
+      i = i + 1
+    end
+
+    match \exhaustive\ name
+    | let n: String =>
+      env.out.print("extracted name: " + n)
+    | None =>
+      env.out.print("name field not found")
+    end

--- a/examples/skip/skip.pony
+++ b/examples/skip/skip.pony
@@ -1,61 +1,9 @@
-// in your code this `use` statement would be:
-// use "msgpack"
-use "../../msgpack"
-use "buffered"
+"""
+Demonstrates `MessagePackDecoder.skip` for forward-compatible
+protocol handling. When a map contains fields your code
+doesn't recognize, `skip` advances past them without needing
+to know their type or structure.
 
-actor Main
-  """
-  Demonstrates `MessagePackDecoder.skip` for forward-compatible
-  protocol handling. When a map contains fields your code
-  doesn't recognize, `skip` advances past them without needing
-  to know their type or structure.
-
-  This is useful for evolving protocols: the sender can add new
-  fields without breaking receivers that don't know about them.
-  """
-  new create(env: Env) =>
-    try
-      _skip_unknown_fields(env)?
-    else
-      env.out.print("error during skip example")
-    end
-
-  fun _skip_unknown_fields(env: Env) ? =>
-    // Encode a map with 3 fields
-    let w: Writer ref = Writer
-    MessagePackEncoder.map(w, 3)
-    MessagePackEncoder.str(w, "name")?
-    MessagePackEncoder.str(w, "alice")?
-    MessagePackEncoder.str(w, "age")?
-    MessagePackEncoder.uint(w, 30)
-    MessagePackEncoder.str(w, "email")?
-    MessagePackEncoder.str(w, "a@b.c")?
-
-    // Transfer to reader
-    let r: Reader ref = Reader
-    for bs in w.done().values() do
-      r.append(bs)
-    end
-
-    // Decode the map, extracting only "name" and
-    // skipping everything else
-    let map_size = MessagePackDecoder.map(r)?
-    var name: (String | None) = None
-    var i: U32 = 0
-    while i < map_size do
-      let key = MessagePackDecoder.str(r)?
-      if (consume key) == "name" then
-        name = MessagePackDecoder.str(r)?
-      else
-        // Skip the value for any unrecognized key
-        MessagePackDecoder.skip(r)?
-      end
-      i = i + 1
-    end
-
-    match name
-    | let n: String =>
-      env.out.print("extracted name: " + n)
-    | None =>
-      env.out.print("name field not found")
-    end
+This is useful for evolving protocols: the sender can add new
+fields without breaking receivers that don't know about them.
+"""

--- a/examples/streaming-decode/main.pony
+++ b/examples/streaming-decode/main.pony
@@ -4,13 +4,6 @@ use "../../msgpack"
 use "buffered"
 
 actor Main
-  """
-  Demonstrates the streaming decoder with containers, mixed
-  types, and realistic chunking. Encodes a map
-  `{"name": "alice", "age": 30}`, splits the bytes into two
-  chunks, and feeds them incrementally. The decoder returns
-  `NotEnoughData` when a chunk boundary falls mid-value.
-  """
   new create(env: Env) =>
     try
       _streaming_decode(env)?
@@ -28,16 +21,17 @@ actor Main
     MessagePackEncoder.uint(w, 30)
 
     // Collect encoded bytes into a contiguous array
-    let encoded = recover val
-      let out = Array[U8]
-      for chunk in w.done().values() do
-        match chunk
-        | let a: Array[U8] val => out.append(a)
-        | let s: String val => out.append(s.array())
+    let encoded =
+      recover val
+        let out = Array[U8]
+        for chunk in w.done().values() do
+          match \exhaustive\ chunk
+          | let a: Array[U8] val => out.append(a)
+          | let s: String val => out.append(s.array())
+          end
         end
+        out
       end
-      out
-    end
 
     // Split at the midpoint to simulate chunked arrival
     let mid = encoded.size() / 2
@@ -47,14 +41,14 @@ actor Main
     let sd = MessagePackStreamingDecoder
 
     // Feed the first chunk and decode until we need more
-    env.out.print("--- feeding chunk 1 ("
-      + mid.string() + " bytes) ---")
+    env.out.print("--- feeding chunk 1 (" +
+      mid.string() + " bytes) ---")
     sd.append(chunk1)
     _decode_loop(sd, env)
 
     // Feed the second chunk and decode the rest
-    env.out.print("--- feeding chunk 2 ("
-      + (encoded.size() - mid).string() + " bytes) ---")
+    env.out.print("--- feeding chunk 2 (" +
+      (encoded.size() - mid).string() + " bytes) ---")
     sd.append(chunk2)
     _decode_loop(sd, env)
 
@@ -66,8 +60,8 @@ actor Main
     while not done do
       match sd.next()
       | let m: MessagePackMap =>
-        env.out.print("map header: "
-          + m.size.string() + " entries")
+        env.out.print("map header: " +
+          m.size.string() + " entries")
       | let s: String val =>
         env.out.print("string: " + s)
       | let v: U8 =>

--- a/examples/streaming-decode/streaming_decode.pony
+++ b/examples/streaming-decode/streaming_decode.pony
@@ -1,0 +1,7 @@
+"""
+Demonstrates the streaming decoder with containers, mixed
+types, and realistic chunking. Encodes a map
+`{"name": "alice", "age": 30}`, splits the bytes into two
+chunks, and feeds them incrementally. The decoder returns
+`NotEnoughData` when a chunk boundary falls mid-value.
+"""

--- a/examples/utf8-validation/main.pony
+++ b/examples/utf8-validation/main.pony
@@ -4,19 +4,6 @@ use "../../msgpack"
 use "buffered"
 
 actor Main
-  """
-  Demonstrates three approaches to UTF-8 validation when
-  encoding or decoding MessagePack str values.
-
-  1. **Validate on encode** — `str_utf8` rejects invalid bytes
-     before they enter the wire format.
-  2. **Validate on streaming decode** — the streaming decoder's
-     `validate_utf8` option returns `InvalidUtf8` for invalid
-     strings.
-  3. **Decode then validate manually** — decode without
-     validation, then check with `MessagePackValidateUTF8`.
-     The raw bytes remain accessible on failure.
-  """
   new create(env: Env) =>
     _validate_on_encode(env)
     _validate_on_streaming_decode(env)
@@ -71,8 +58,8 @@ actor Main
     end
 
     // Decode with validation enabled
-    let sd = MessagePackStreamingDecoder(
-      where validate_utf8' = true)
+    let sd =
+      MessagePackStreamingDecoder(where validate_utf8' = true)
     for bs in w.done().values() do
       sd.append(bs)
     end
@@ -115,9 +102,9 @@ actor Main
       if MessagePackValidateUTF8(s) then
         env.out.print("valid UTF-8: " + s)
       else
-        env.out.print("invalid UTF-8 detected manually"
-          + " (raw bytes still available, size="
-          + s.size().string() + ")")
+        env.out.print("invalid UTF-8 detected manually" +
+          " (raw bytes still available, size=" +
+          s.size().string() + ")")
       end
     else
       env.out.print("decode error (unexpected)")

--- a/examples/utf8-validation/utf8_validation.pony
+++ b/examples/utf8-validation/utf8_validation.pony
@@ -1,0 +1,13 @@
+"""
+Demonstrates three approaches to UTF-8 validation when
+encoding or decoding MessagePack str values.
+
+1. **Validate on encode** — `str_utf8` rejects invalid bytes
+   before they enter the wire format.
+2. **Validate on streaming decode** — the streaming decoder's
+   `validate_utf8` option returns `InvalidUtf8` for invalid
+   strings.
+3. **Decode then validate manually** — decode without
+   validation, then check with `MessagePackValidateUTF8`.
+   The raw bytes remain accessible on failure.
+"""

--- a/examples/zero-copy-decode/main.pony
+++ b/examples/zero-copy-decode/main.pony
@@ -4,18 +4,6 @@ use "../../msgpack"
 use "buffered"
 
 actor Main
-  """
-  Demonstrates zero-copy decoding using `ZeroCopyReader` and
-  `MessagePackZeroCopyDecoder`. Variable-length values (strings,
-  binary data) are returned as `val` views into the reader's
-  internal buffer instead of freshly allocated copies.
-
-  This avoids allocation for decoded strings and byte arrays
-  when the data falls within a single chunk in the reader. The
-  trade-off is that decoded values hold a reference to the
-  source chunk, keeping it in memory until the decoded value is
-  discarded.
-  """
   new create(env: Env) =>
     try
       _zero_copy_decode(env)?
@@ -41,12 +29,12 @@ actor Main
     MessagePackZeroCopyDecoder.nil(r)?
     env.out.print("decoded nil")
 
-    env.out.print("decoded bool: "
-      + MessagePackZeroCopyDecoder.bool(r)?.string())
+    env.out.print("decoded bool: " +
+      MessagePackZeroCopyDecoder.bool(r)?.string())
 
-    env.out.print("decoded uint: "
-      + MessagePackZeroCopyDecoder.uint(r)?.string())
+    env.out.print("decoded uint: " +
+      MessagePackZeroCopyDecoder.uint(r)?.string())
 
     // str() returns String val (a view), not String iso^
-    env.out.print("decoded str: "
-      + MessagePackZeroCopyDecoder.str(r)?)
+    env.out.print("decoded str: " +
+      MessagePackZeroCopyDecoder.str(r)?)

--- a/examples/zero-copy-decode/zero_copy_decode.pony
+++ b/examples/zero-copy-decode/zero_copy_decode.pony
@@ -1,0 +1,12 @@
+"""
+Demonstrates zero-copy decoding using `ZeroCopyReader` and
+`MessagePackZeroCopyDecoder`. Variable-length values (strings,
+binary data) are returned as `val` views into the reader's
+internal buffer instead of freshly allocated copies.
+
+This avoids allocation for decoded strings and byte arrays
+when the data falls within a single chunk in the reader. The
+trade-off is that decoded values hold a reference to the
+source chunk, keeping it in memory until the decoded value is
+discarded.
+"""

--- a/msgpack/_format_name.pony
+++ b/msgpack/_format_name.pony
@@ -1,21 +1,3 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 primitive _FormatName
   fun positive_fixint(): U8 => 0x00
   fun fixmap(): U8 => 0x80

--- a/msgpack/_limit.pony
+++ b/msgpack/_limit.pony
@@ -1,21 +1,3 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 primitive _Limit
   fun fixarray(): U8 => 15
   fun fixmap(): U8 => 15

--- a/msgpack/_size.pony
+++ b/msgpack/_size.pony
@@ -1,21 +1,3 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 primitive _Size
   fun fixext_1(): USize => 1
   fun fixext_2(): USize => 2

--- a/msgpack/_test.pony
+++ b/msgpack/_test.pony
@@ -1,21 +1,3 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 use "pony_test"
 
 actor \nodoc\ Main is TestList

--- a/msgpack/_test_decoder.pony
+++ b/msgpack/_test_decoder.pony
@@ -1,21 +1,3 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 use "buffered"
 use "collections"
 use "pony_check"
@@ -895,7 +877,7 @@ class \nodoc\ _TestDecodeTimestamp32 is UnitTest
   fun name(): String =>
     "msgpack/DecodeTimestamp32"
 
-  fun ref apply(h: TestHelper)? =>
+  fun ref apply(h: TestHelper) ? =>
     let encoded_sec: U32 = 500
     let b: Reader ref = Reader
     let w: Writer ref = Writer
@@ -914,7 +896,7 @@ class \nodoc\ _TestDecodeTimestamp64 is UnitTest
   fun name(): String =>
     "msgpack/DecodeTimestamp64"
 
-  fun ref apply(h: TestHelper)? =>
+  fun ref apply(h: TestHelper) ? =>
     let encoded_sec = U64(_Limit.sec_34())
     let encoded_nsec = U32(_Limit.nsec())
     let b: Reader ref = Reader
@@ -934,7 +916,7 @@ class \nodoc\ _TestDecodeTimestamp96 is UnitTest
   fun name(): String =>
     "msgpack/DecodeTimestamp96"
 
-  fun ref apply(h: TestHelper)? =>
+  fun ref apply(h: TestHelper) ? =>
     let encoded_sec = 0 - _Limit.sec_34().i64()
     let encoded_nsec = _Limit.nsec()
     let b: Reader ref = Reader
@@ -978,7 +960,9 @@ class \nodoc\ _TestDecodeCompactUint is UnitTest
       b.append(bs)
     end
 
-    h.assert_eq[U64](v, MessagePackDecoder.uint(b)?,
+    h.assert_eq[U64](
+      v,
+      MessagePackDecoder.uint(b)?,
       "roundtrip " + v.string())
 
 class \nodoc\ _TestDecodeCompactInt is UnitTest
@@ -1018,7 +1002,9 @@ class \nodoc\ _TestDecodeCompactInt is UnitTest
       b.append(bs)
     end
 
-    h.assert_eq[I64](v, MessagePackDecoder.int(b)?,
+    h.assert_eq[I64](
+      v,
+      MessagePackDecoder.int(b)?,
       "roundtrip " + v.string())
 
 class \nodoc\ _TestDecodeCompactStr is UnitTest
@@ -1033,10 +1019,11 @@ class \nodoc\ _TestDecodeCompactStr is UnitTest
     // fixstr (short string)
     _check(h, "Hello")?
     // str_8 (32 bytes, above fixstr limit)
-    let medium = recover val
-      String.from_array(
-        recover val Array[U8].init('M', 32) end)
-    end
+    let medium =
+      recover val
+        String.from_array(
+          recover val Array[U8].init('M', 32) end)
+      end
     _check(h, medium)?
 
   fun _check(h: TestHelper, v: String val) ? =>
@@ -1049,7 +1036,8 @@ class \nodoc\ _TestDecodeCompactStr is UnitTest
       b.append(bs)
     end
 
-    h.assert_eq[String](v,
+    h.assert_eq[String](
+      v,
       MessagePackDecoder.str(b)?,
       "roundtrip len=" + v.size().string())
 
@@ -1076,7 +1064,9 @@ class \nodoc\ _TestDecodeCompactArray is UnitTest
       b.append(bs)
     end
 
-    h.assert_eq[U32](v, MessagePackDecoder.array(b)?,
+    h.assert_eq[U32](
+      v,
+      MessagePackDecoder.array(b)?,
       "roundtrip " + v.string())
 
 class \nodoc\ _TestDecodeCompactMap is UnitTest
@@ -1102,7 +1092,9 @@ class \nodoc\ _TestDecodeCompactMap is UnitTest
       b.append(bs)
     end
 
-    h.assert_eq[U32](v, MessagePackDecoder.map(b)?,
+    h.assert_eq[U32](
+      v,
+      MessagePackDecoder.map(b)?,
       "roundtrip " + v.string())
 
 class \nodoc\ _TestDecodeCompactExt is UnitTest
@@ -1128,9 +1120,8 @@ class \nodoc\ _TestDecodeCompactExt is UnitTest
     data_size: USize)
     ?
   =>
-    let value = recover val
-      Array[U8].init('X', data_size)
-    end
+    let value =
+      recover val Array[U8].init('X', data_size) end
     let w: Writer ref = Writer
     let b: Reader ref = Reader
 
@@ -1141,13 +1132,15 @@ class \nodoc\ _TestDecodeCompactExt is UnitTest
     end
 
     (let dt, let dv) = MessagePackDecoder.ext(b)?
-    h.assert_eq[U8](t, dt,
-      "type for size=" + data_size.string())
-    h.assert_eq[USize](data_size, dv.size(),
+    h.assert_eq[U8](
+      t, dt, "type for size=" + data_size.string())
+    h.assert_eq[USize](
+      data_size,
+      dv.size(),
       "data size for size=" + data_size.string())
     for i in Range(0, data_size) do
-      h.assert_eq[U8]('X', dv(i)?,
-        "data byte " + i.string())
+      h.assert_eq[U8](
+        'X', dv(i)?, "data byte " + i.string())
     end
 
 class \nodoc\ _TestDecodeCompactTimestamp is UnitTest
@@ -1182,12 +1175,16 @@ class \nodoc\ _TestDecodeCompactTimestamp is UnitTest
     end
 
     (let ds, let dn) = MessagePackDecoder.timestamp(b)?
-    h.assert_eq[I64](sec, ds,
-      "sec for (" + sec.string() + ", "
-        + nsec.string() + ")")
-    h.assert_eq[U32](nsec, dn,
-      "nsec for (" + sec.string() + ", "
-        + nsec.string() + ")")
+    h.assert_eq[I64](
+      sec,
+      ds,
+      "sec for (" + sec.string() + ", " +
+        nsec.string() + ")")
+    h.assert_eq[U32](
+      nsec,
+      dn,
+      "nsec for (" + sec.string() + ", " +
+        nsec.string() + ")")
 
 class \nodoc\ _TestDecodeCompactUintRejects is UnitTest
   """
@@ -1215,8 +1212,8 @@ class \nodoc\ _TestDecodeCompactUintRejects is UnitTest
       recover val [as U8: format_byte] end)
     try
       MessagePackDecoder.uint(b)?
-      h.fail("uint accepted 0x"
-        + format_byte.string())
+      h.fail("uint accepted 0x" +
+        format_byte.string())
     end
 
 class \nodoc\ _TestDecodeCompactIntRejects is UnitTest
@@ -1243,8 +1240,7 @@ class \nodoc\ _TestDecodeCompactIntRejects is UnitTest
       recover val [as U8: format_byte] end)
     try
       MessagePackDecoder.int(b)?
-      h.fail("int accepted 0x"
-        + format_byte.string())
+      h.fail("int accepted 0x" + format_byte.string())
     end
 
 class \nodoc\ _TestDecodeCompactArrayRejects is UnitTest
@@ -1269,8 +1265,8 @@ class \nodoc\ _TestDecodeCompactArrayRejects is UnitTest
       recover val [as U8: format_byte] end)
     try
       MessagePackDecoder.array(b)?
-      h.fail("array accepted 0x"
-        + format_byte.string())
+      h.fail(
+        "array accepted 0x" + format_byte.string())
     end
 
 class \nodoc\ _TestDecodeCompactMapRejects is UnitTest
@@ -1294,8 +1290,8 @@ class \nodoc\ _TestDecodeCompactMapRejects is UnitTest
       recover val [as U8: format_byte] end)
     try
       MessagePackDecoder.map(b)?
-      h.fail("map accepted 0x"
-        + format_byte.string())
+      h.fail(
+        "map accepted 0x" + format_byte.string())
     end
 
 class \nodoc\ _PropertyCompactUintRoundtrip
@@ -1308,18 +1304,18 @@ class \nodoc\ _PropertyCompactUintRoundtrip
     "msgpack/PropertyCompactUintRoundtrip"
 
   fun gen(): Generator[U64] =>
-    Generators.frequency[U64]([
-      as WeightedGenerator[U64]:
-      (2, Generators.u8().map[U64]({(v) =>
-        (v and 0x7F).u64()}))              // fixint
-      (2, Generators.u8().map[U64]({(v) =>
-        (v or 0x80).u64()}))               // uint_8
-      (2, Generators.u16().map[U64]({(v) =>
-        v.u64() + 256}))                   // uint_16
-      (2, Generators.u32().map[U64]({(v) =>
-        v.u64() + 65536}))                 // uint_32
-      (2, Generators.u64())                // uint_64
-    ])
+    Generators.frequency[U64](
+      [ as WeightedGenerator[U64]:
+        (2, Generators.u8().map[U64]({(v) =>
+          (v and 0x7F).u64()}))            // fixint
+        (2, Generators.u8().map[U64]({(v) =>
+          (v or 0x80).u64()}))             // uint_8
+        (2, Generators.u16().map[U64]({(v) =>
+          v.u64() + 256}))                 // uint_16
+        (2, Generators.u32().map[U64]({(v) =>
+          v.u64() + 65536}))               // uint_32
+        (2, Generators.u64())              // uint_64
+      ])
 
   fun ref property(arg1: U64, h: PropertyHelper) ? =>
     let w: Writer ref = Writer
@@ -1331,7 +1327,8 @@ class \nodoc\ _PropertyCompactUintRoundtrip
       b.append(bs)
     end
 
-    h.assert_eq[U64](arg1, MessagePackDecoder.uint(b)?)
+    h.assert_eq[U64](
+      arg1, MessagePackDecoder.uint(b)?)
 
 class \nodoc\ _PropertyCompactIntRoundtrip
   is Property1[I64]
@@ -1343,26 +1340,26 @@ class \nodoc\ _PropertyCompactIntRoundtrip
     "msgpack/PropertyCompactIntRoundtrip"
 
   fun gen(): Generator[I64] =>
-    Generators.frequency[I64]([
-      as WeightedGenerator[I64]:
-      (2, Generators.u8().map[I64]({(v) =>
-        (v and 0x7F).i64()}))              // pos fixint
-      (2, Generators.u8().map[I64]({(v) =>
-        -((v % 32).i64() + 1)}))           // neg fixint
-      (1, Generators.u8().map[I64]({(v) =>
-        (v or 0x80).i64()}))               // uint_8
-      (1, Generators.u8().map[I64]({(v) =>
-        -((v % 96).i64() + 33)}))          // int_8
-      (1, Generators.u16().map[I64]({(v) =>
-        v.i64() + 256}))                   // uint_16
-      (1, Generators.u16().map[I64]({(v) =>
-        -(v.i64() + 129)}))                // int_16
-      (1, Generators.u32().map[I64]({(v) =>
-        v.i64() + 65536}))                 // uint_32
-      (1, Generators.u32().map[I64]({(v) =>
-        -(v.i64() + 32769)}))              // int_32
-      (1, Generators.i64())                // int_64/uint_64
-    ])
+    Generators.frequency[I64](
+      [ as WeightedGenerator[I64]:
+        (2, Generators.u8().map[I64]({(v) =>
+          (v and 0x7F).i64()}))            // pos fixint
+        (2, Generators.u8().map[I64]({(v) =>
+          -((v % 32).i64() + 1)}))         // neg fixint
+        (1, Generators.u8().map[I64]({(v) =>
+          (v or 0x80).i64()}))             // uint_8
+        (1, Generators.u8().map[I64]({(v) =>
+          -((v % 96).i64() + 33)}))        // int_8
+        (1, Generators.u16().map[I64]({(v) =>
+          v.i64() + 256}))                 // uint_16
+        (1, Generators.u16().map[I64]({(v) =>
+          -(v.i64() + 129)}))              // int_16
+        (1, Generators.u32().map[I64]({(v) =>
+          v.i64() + 65536}))               // uint_32
+        (1, Generators.u32().map[I64]({(v) =>
+          -(v.i64() + 32769)}))            // int_32
+        (1, Generators.i64())              // int_64/uint_64
+      ])
 
   fun ref property(arg1: I64, h: PropertyHelper) ? =>
     let w: Writer ref = Writer
@@ -1374,7 +1371,8 @@ class \nodoc\ _PropertyCompactIntRoundtrip
       b.append(bs)
     end
 
-    h.assert_eq[I64](arg1, MessagePackDecoder.int(b)?)
+    h.assert_eq[I64](
+      arg1, MessagePackDecoder.int(b)?)
 
 class \nodoc\ _PropertyCompactStrRoundtrip
   is Property1[String]
@@ -1387,16 +1385,16 @@ class \nodoc\ _PropertyCompactStrRoundtrip
     "msgpack/PropertyCompactStrRoundtrip"
 
   fun gen(): Generator[String] =>
-    Generators.frequency[String]([
-      as WeightedGenerator[String]:
-      (5, Generators.ascii_printable(
-        0, _Limit.fixstr()))
-      (3, Generators.ascii_printable(
-        _Limit.fixstr() + 1,
-        U8.max_value().usize()))
-      (2, Generators.ascii_printable(
-        U8.max_value().usize() + 1, 300))
-    ])
+    Generators.frequency[String](
+      [ as WeightedGenerator[String]:
+        (5, Generators.ascii_printable(
+          0, _Limit.fixstr()))
+        (3, Generators.ascii_printable(
+          _Limit.fixstr() + 1,
+          U8.max_value().usize()))
+        (2, Generators.ascii_printable(
+          U8.max_value().usize() + 1, 300))
+      ])
 
   fun ref property(arg1: String, h: PropertyHelper) ? =>
     let s: String val = arg1.clone()
@@ -1409,7 +1407,8 @@ class \nodoc\ _PropertyCompactStrRoundtrip
       b.append(bs)
     end
 
-    h.assert_eq[String](s, MessagePackDecoder.str(b)?)
+    h.assert_eq[String](
+      s, MessagePackDecoder.str(b)?)
 
 class \nodoc\ _PropertyCompactArrayRoundtrip
   is Property1[U32]
@@ -1421,16 +1420,16 @@ class \nodoc\ _PropertyCompactArrayRoundtrip
     "msgpack/PropertyCompactArrayRoundtrip"
 
   fun gen(): Generator[U32] =>
-    Generators.frequency[U32]([
-      as WeightedGenerator[U32]:
-      (3, Generators.u8().map[U32]({(v) =>
-        (v and 0x0F).u32()}))              // fixarray
-      (3, Generators.u16().map[U32]({(v) =>
-        v.u32() + 16}))                    // array_16
-      (4, Generators.u32().map[U32]({(v) =>
-        if v < 65536 then v + 65536
-        else v end}))                      // array_32
-    ])
+    Generators.frequency[U32](
+      [ as WeightedGenerator[U32]:
+        (3, Generators.u8().map[U32]({(v) =>
+          (v and 0x0F).u32()}))            // fixarray
+        (3, Generators.u16().map[U32]({(v) =>
+          v.u32() + 16}))                  // array_16
+        (4, Generators.u32().map[U32]({(v) =>
+          if v < 65536 then v + 65536
+          else v end}))                    // array_32
+      ])
 
   fun ref property(arg1: U32, h: PropertyHelper) ? =>
     let w: Writer ref = Writer
@@ -1442,7 +1441,8 @@ class \nodoc\ _PropertyCompactArrayRoundtrip
       b.append(bs)
     end
 
-    h.assert_eq[U32](arg1, MessagePackDecoder.array(b)?)
+    h.assert_eq[U32](
+      arg1, MessagePackDecoder.array(b)?)
 
 class \nodoc\ _PropertyCompactMapRoundtrip
   is Property1[U32]
@@ -1454,16 +1454,16 @@ class \nodoc\ _PropertyCompactMapRoundtrip
     "msgpack/PropertyCompactMapRoundtrip"
 
   fun gen(): Generator[U32] =>
-    Generators.frequency[U32]([
-      as WeightedGenerator[U32]:
-      (3, Generators.u8().map[U32]({(v) =>
-        (v and 0x0F).u32()}))              // fixmap
-      (3, Generators.u16().map[U32]({(v) =>
-        v.u32() + 16}))                    // map_16
-      (4, Generators.u32().map[U32]({(v) =>
-        if v < 65536 then v + 65536
-        else v end}))                      // map_32
-    ])
+    Generators.frequency[U32](
+      [ as WeightedGenerator[U32]:
+        (3, Generators.u8().map[U32]({(v) =>
+          (v and 0x0F).u32()}))            // fixmap
+        (3, Generators.u16().map[U32]({(v) =>
+          v.u32() + 16}))                  // map_16
+        (4, Generators.u32().map[U32]({(v) =>
+          if v < 65536 then v + 65536
+          else v end}))                    // map_32
+      ])
 
   fun ref property(arg1: U32, h: PropertyHelper) ? =>
     let w: Writer ref = Writer
@@ -1475,7 +1475,8 @@ class \nodoc\ _PropertyCompactMapRoundtrip
       b.append(bs)
     end
 
-    h.assert_eq[U32](arg1, MessagePackDecoder.map(b)?)
+    h.assert_eq[U32](
+      arg1, MessagePackDecoder.map(b)?)
 
 class \nodoc\ _PropertyCompactUintSmallestSize
   is Property1[U64]
@@ -1489,18 +1490,18 @@ class \nodoc\ _PropertyCompactUintSmallestSize
     "msgpack/PropertyCompactUintSmallestSize"
 
   fun gen(): Generator[U64] =>
-    Generators.frequency[U64]([
-      as WeightedGenerator[U64]:
-      (2, Generators.u8().map[U64]({(v) =>
-        (v and 0x7F).u64()}))              // fixint
-      (2, Generators.u8().map[U64]({(v) =>
-        (v or 0x80).u64()}))               // uint_8
-      (2, Generators.u16().map[U64]({(v) =>
-        v.u64() + 256}))                   // uint_16
-      (2, Generators.u32().map[U64]({(v) =>
-        v.u64() + 65536}))                 // uint_32
-      (2, Generators.u64())                // uint_64
-    ])
+    Generators.frequency[U64](
+      [ as WeightedGenerator[U64]:
+        (2, Generators.u8().map[U64]({(v) =>
+          (v and 0x7F).u64()}))            // fixint
+        (2, Generators.u8().map[U64]({(v) =>
+          (v or 0x80).u64()}))             // uint_8
+        (2, Generators.u16().map[U64]({(v) =>
+          v.u64() + 256}))                 // uint_16
+        (2, Generators.u32().map[U64]({(v) =>
+          v.u64() + 65536}))               // uint_32
+        (2, Generators.u64())              // uint_64
+      ])
 
   fun ref property(arg1: U64, h: PropertyHelper) ? =>
     let wc: Writer ref = Writer
@@ -1510,40 +1511,45 @@ class \nodoc\ _PropertyCompactUintSmallestSize
     // uint_64 is always applicable
     let w64: Writer ref = Writer
     MessagePackEncoder.uint_64(w64, arg1)
-    h.assert_true(compact <= _writer_size(w64),
+    h.assert_true(
+      compact <= _writer_size(w64),
       "compact <= uint_64 for " + arg1.string())
 
     if arg1 <= U32.max_value().u64() then
       let w32: Writer ref = Writer
       MessagePackEncoder.uint_32(w32, arg1.u32())
-      h.assert_true(compact <= _writer_size(w32),
-        "compact <= uint_32 for "
-          + arg1.string())
+      h.assert_true(
+        compact <= _writer_size(w32),
+        "compact <= uint_32 for " +
+          arg1.string())
     end
 
     if arg1 <= U16.max_value().u64() then
       let w16: Writer ref = Writer
       MessagePackEncoder.uint_16(w16, arg1.u16())
-      h.assert_true(compact <= _writer_size(w16),
-        "compact <= uint_16 for "
-          + arg1.string())
+      h.assert_true(
+        compact <= _writer_size(w16),
+        "compact <= uint_16 for " +
+          arg1.string())
     end
 
     if arg1 <= U8.max_value().u64() then
       let w8: Writer ref = Writer
       MessagePackEncoder.uint_8(w8, arg1.u8())
-      h.assert_true(compact <= _writer_size(w8),
-        "compact <= uint_8 for "
-          + arg1.string())
+      h.assert_true(
+        compact <= _writer_size(w8),
+        "compact <= uint_8 for " +
+          arg1.string())
     end
 
     if arg1 <= _Limit.positive_fixint().u64() then
       let wf: Writer ref = Writer
-      MessagePackEncoder.positive_fixint(wf,
-        arg1.u8())?
-      h.assert_true(compact <= _writer_size(wf),
-        "compact <= fixint for "
-          + arg1.string())
+      MessagePackEncoder.positive_fixint(
+        wf, arg1.u8())?
+      h.assert_true(
+        compact <= _writer_size(wf),
+        "compact <= fixint for " +
+          arg1.string())
     end
 
   fun _writer_size(w: Writer ref): USize =>
@@ -1564,26 +1570,26 @@ class \nodoc\ _PropertyCompactIntSmallestSize
     "msgpack/PropertyCompactIntSmallestSize"
 
   fun gen(): Generator[I64] =>
-    Generators.frequency[I64]([
-      as WeightedGenerator[I64]:
-      (2, Generators.u8().map[I64]({(v) =>
-        (v and 0x7F).i64()}))              // pos fixint
-      (2, Generators.u8().map[I64]({(v) =>
-        -((v % 32).i64() + 1)}))           // neg fixint
-      (1, Generators.u8().map[I64]({(v) =>
-        (v or 0x80).i64()}))               // uint_8
-      (1, Generators.u8().map[I64]({(v) =>
-        -((v % 96).i64() + 33)}))          // int_8
-      (1, Generators.u16().map[I64]({(v) =>
-        v.i64() + 256}))                   // uint_16
-      (1, Generators.u16().map[I64]({(v) =>
-        -(v.i64() + 129)}))                // int_16
-      (1, Generators.u32().map[I64]({(v) =>
-        v.i64() + 65536}))                 // uint_32
-      (1, Generators.u32().map[I64]({(v) =>
-        -(v.i64() + 32769)}))              // int_32
-      (1, Generators.i64())                // int_64/uint_64
-    ])
+    Generators.frequency[I64](
+      [ as WeightedGenerator[I64]:
+        (2, Generators.u8().map[I64]({(v) =>
+          (v and 0x7F).i64()}))            // pos fixint
+        (2, Generators.u8().map[I64]({(v) =>
+          -((v % 32).i64() + 1)}))         // neg fixint
+        (1, Generators.u8().map[I64]({(v) =>
+          (v or 0x80).i64()}))             // uint_8
+        (1, Generators.u8().map[I64]({(v) =>
+          -((v % 96).i64() + 33)}))        // int_8
+        (1, Generators.u16().map[I64]({(v) =>
+          v.i64() + 256}))                 // uint_16
+        (1, Generators.u16().map[I64]({(v) =>
+          -(v.i64() + 129)}))              // int_16
+        (1, Generators.u32().map[I64]({(v) =>
+          v.i64() + 65536}))               // uint_32
+        (1, Generators.u32().map[I64]({(v) =>
+          -(v.i64() + 32769)}))            // int_32
+        (1, Generators.i64())              // int_64/uint_64
+      ])
 
   fun ref property(arg1: I64, h: PropertyHelper) =>
     let wc: Writer ref = Writer
@@ -1593,37 +1599,41 @@ class \nodoc\ _PropertyCompactIntSmallestSize
     // int_64 is always applicable
     let w64: Writer ref = Writer
     MessagePackEncoder.int_64(w64, arg1)
-    h.assert_true(compact <= _writer_size(w64),
+    h.assert_true(
+      compact <= _writer_size(w64),
       "compact <= int_64 for " + arg1.string())
 
-    if (arg1 >= I32.min_value().i64())
-      and (arg1 <= I32.max_value().i64())
+    if (arg1 >= I32.min_value().i64()) and
+      (arg1 <= I32.max_value().i64())
     then
       let w32: Writer ref = Writer
       MessagePackEncoder.int_32(w32, arg1.i32())
-      h.assert_true(compact <= _writer_size(w32),
-        "compact <= int_32 for "
-          + arg1.string())
+      h.assert_true(
+        compact <= _writer_size(w32),
+        "compact <= int_32 for " +
+          arg1.string())
     end
 
-    if (arg1 >= I16.min_value().i64())
-      and (arg1 <= I16.max_value().i64())
+    if (arg1 >= I16.min_value().i64()) and
+      (arg1 <= I16.max_value().i64())
     then
       let w16: Writer ref = Writer
       MessagePackEncoder.int_16(w16, arg1.i16())
-      h.assert_true(compact <= _writer_size(w16),
-        "compact <= int_16 for "
-          + arg1.string())
+      h.assert_true(
+        compact <= _writer_size(w16),
+        "compact <= int_16 for " +
+          arg1.string())
     end
 
-    if (arg1 >= I8.min_value().i64())
-      and (arg1 <= I8.max_value().i64())
+    if (arg1 >= I8.min_value().i64()) and
+      (arg1 <= I8.max_value().i64())
     then
       let w8: Writer ref = Writer
       MessagePackEncoder.int_8(w8, arg1.i8())
-      h.assert_true(compact <= _writer_size(w8),
-        "compact <= int_8 for "
-          + arg1.string())
+      h.assert_true(
+        compact <= _writer_size(w8),
+        "compact <= int_8 for " +
+          arg1.string())
     end
 
     if arg1 >= 0 then
@@ -1632,33 +1642,33 @@ class \nodoc\ _PropertyCompactIntSmallestSize
         MessagePackEncoder.uint_8(wu8, arg1.u8())
         h.assert_true(
           compact <= _writer_size(wu8),
-          "compact <= uint_8 for "
-            + arg1.string())
+          "compact <= uint_8 for " +
+            arg1.string())
       end
       if arg1 <= U16.max_value().i64() then
         let wu16: Writer ref = Writer
-        MessagePackEncoder.uint_16(wu16,
-          arg1.u16())
+        MessagePackEncoder.uint_16(
+          wu16, arg1.u16())
         h.assert_true(
           compact <= _writer_size(wu16),
-          "compact <= uint_16 for "
-            + arg1.string())
+          "compact <= uint_16 for " +
+            arg1.string())
       end
       if arg1 <= U32.max_value().i64() then
         let wu32: Writer ref = Writer
-        MessagePackEncoder.uint_32(wu32,
-          arg1.u32())
+        MessagePackEncoder.uint_32(
+          wu32, arg1.u32())
         h.assert_true(
           compact <= _writer_size(wu32),
-          "compact <= uint_32 for "
-            + arg1.string())
+          "compact <= uint_32 for " +
+            arg1.string())
       end
       let wu64: Writer ref = Writer
       MessagePackEncoder.uint_64(wu64, arg1.u64())
       h.assert_true(
         compact <= _writer_size(wu64),
-        "compact <= uint_64 for "
-          + arg1.string())
+        "compact <= uint_64 for " +
+          arg1.string())
     end
 
   fun _writer_size(w: Writer ref): USize =>
@@ -1679,16 +1689,16 @@ class \nodoc\ _PropertyCompactStrSmallestSize
     "msgpack/PropertyCompactStrSmallestSize"
 
   fun gen(): Generator[String] =>
-    Generators.frequency[String]([
-      as WeightedGenerator[String]:
-      (5, Generators.ascii_printable(
-        0, _Limit.fixstr()))
-      (3, Generators.ascii_printable(
-        _Limit.fixstr() + 1,
-        U8.max_value().usize()))
-      (2, Generators.ascii_printable(
-        U8.max_value().usize() + 1, 300))
-    ])
+    Generators.frequency[String](
+      [ as WeightedGenerator[String]:
+        (5, Generators.ascii_printable(
+          0, _Limit.fixstr()))
+        (3, Generators.ascii_printable(
+          _Limit.fixstr() + 1,
+          U8.max_value().usize()))
+        (2, Generators.ascii_printable(
+          U8.max_value().usize() + 1, 300))
+      ])
 
   fun ref property(arg1: String, h: PropertyHelper)
     ?
@@ -1701,32 +1711,36 @@ class \nodoc\ _PropertyCompactStrSmallestSize
     // str_32 is always applicable for test sizes
     let w32: Writer ref = Writer
     MessagePackEncoder.str_32(w32, s)?
-    h.assert_true(compact <= _writer_size(w32),
-      "compact <= str_32 for len="
-        + s.size().string())
+    h.assert_true(
+      compact <= _writer_size(w32),
+      "compact <= str_32 for len=" +
+        s.size().string())
 
     if s.size() <= U16.max_value().usize() then
       let w16: Writer ref = Writer
       MessagePackEncoder.str_16(w16, s)?
-      h.assert_true(compact <= _writer_size(w16),
-        "compact <= str_16 for len="
-          + s.size().string())
+      h.assert_true(
+        compact <= _writer_size(w16),
+        "compact <= str_16 for len=" +
+          s.size().string())
     end
 
     if s.size() <= U8.max_value().usize() then
       let w8: Writer ref = Writer
       MessagePackEncoder.str_8(w8, s)?
-      h.assert_true(compact <= _writer_size(w8),
-        "compact <= str_8 for len="
-          + s.size().string())
+      h.assert_true(
+        compact <= _writer_size(w8),
+        "compact <= str_8 for len=" +
+          s.size().string())
     end
 
     if s.size() <= _Limit.fixstr() then
       let wf: Writer ref = Writer
       MessagePackEncoder.fixstr(wf, s)?
-      h.assert_true(compact <= _writer_size(wf),
-        "compact <= fixstr for len="
-          + s.size().string())
+      h.assert_true(
+        compact <= _writer_size(wf),
+        "compact <= fixstr for len=" +
+          s.size().string())
     end
 
   fun _writer_size(w: Writer ref): USize =>
@@ -1747,16 +1761,16 @@ class \nodoc\ _PropertyCompactArraySmallestSize
     "msgpack/PropertyCompactArraySmallestSize"
 
   fun gen(): Generator[U32] =>
-    Generators.frequency[U32]([
-      as WeightedGenerator[U32]:
-      (3, Generators.u8().map[U32]({(v) =>
-        (v and 0x0F).u32()}))              // fixarray
-      (3, Generators.u16().map[U32]({(v) =>
-        v.u32() + 16}))                    // array_16
-      (4, Generators.u32().map[U32]({(v) =>
-        if v < 65536 then v + 65536
-        else v end}))                      // array_32
-    ])
+    Generators.frequency[U32](
+      [ as WeightedGenerator[U32]:
+        (3, Generators.u8().map[U32]({(v) =>
+          (v and 0x0F).u32()}))            // fixarray
+        (3, Generators.u16().map[U32]({(v) =>
+          v.u32() + 16}))                  // array_16
+        (4, Generators.u32().map[U32]({(v) =>
+          if v < 65536 then v + 65536
+          else v end}))                    // array_32
+      ])
 
   fun ref property(arg1: U32, h: PropertyHelper) ? =>
     let wc: Writer ref = Writer
@@ -1766,24 +1780,27 @@ class \nodoc\ _PropertyCompactArraySmallestSize
     // array_32 is always applicable
     let w32: Writer ref = Writer
     MessagePackEncoder.array_32(w32, arg1)
-    h.assert_true(compact <= _writer_size(w32),
-      "compact <= array_32 for "
-        + arg1.string())
+    h.assert_true(
+      compact <= _writer_size(w32),
+      "compact <= array_32 for " +
+        arg1.string())
 
     if arg1 <= U16.max_value().u32() then
       let w16: Writer ref = Writer
       MessagePackEncoder.array_16(w16, arg1.u16())
-      h.assert_true(compact <= _writer_size(w16),
-        "compact <= array_16 for "
-          + arg1.string())
+      h.assert_true(
+        compact <= _writer_size(w16),
+        "compact <= array_16 for " +
+          arg1.string())
     end
 
     if arg1 <= _Limit.fixarray().u32() then
       let wf: Writer ref = Writer
       MessagePackEncoder.fixarray(wf, arg1.u8())?
-      h.assert_true(compact <= _writer_size(wf),
-        "compact <= fixarray for "
-          + arg1.string())
+      h.assert_true(
+        compact <= _writer_size(wf),
+        "compact <= fixarray for " +
+          arg1.string())
     end
 
   fun _writer_size(w: Writer ref): USize =>
@@ -1804,16 +1821,16 @@ class \nodoc\ _PropertyCompactMapSmallestSize
     "msgpack/PropertyCompactMapSmallestSize"
 
   fun gen(): Generator[U32] =>
-    Generators.frequency[U32]([
-      as WeightedGenerator[U32]:
-      (3, Generators.u8().map[U32]({(v) =>
-        (v and 0x0F).u32()}))              // fixmap
-      (3, Generators.u16().map[U32]({(v) =>
-        v.u32() + 16}))                    // map_16
-      (4, Generators.u32().map[U32]({(v) =>
-        if v < 65536 then v + 65536
-        else v end}))                      // map_32
-    ])
+    Generators.frequency[U32](
+      [ as WeightedGenerator[U32]:
+        (3, Generators.u8().map[U32]({(v) =>
+          (v and 0x0F).u32()}))            // fixmap
+        (3, Generators.u16().map[U32]({(v) =>
+          v.u32() + 16}))                  // map_16
+        (4, Generators.u32().map[U32]({(v) =>
+          if v < 65536 then v + 65536
+          else v end}))                    // map_32
+      ])
 
   fun ref property(arg1: U32, h: PropertyHelper) ? =>
     let wc: Writer ref = Writer
@@ -1823,24 +1840,27 @@ class \nodoc\ _PropertyCompactMapSmallestSize
     // map_32 is always applicable
     let w32: Writer ref = Writer
     MessagePackEncoder.map_32(w32, arg1)
-    h.assert_true(compact <= _writer_size(w32),
-      "compact <= map_32 for "
-        + arg1.string())
+    h.assert_true(
+      compact <= _writer_size(w32),
+      "compact <= map_32 for " +
+        arg1.string())
 
     if arg1 <= U16.max_value().u32() then
       let w16: Writer ref = Writer
       MessagePackEncoder.map_16(w16, arg1.u16())
-      h.assert_true(compact <= _writer_size(w16),
-        "compact <= map_16 for "
-          + arg1.string())
+      h.assert_true(
+        compact <= _writer_size(w16),
+        "compact <= map_16 for " +
+          arg1.string())
     end
 
     if arg1 <= _Limit.fixmap().u32() then
       let wf: Writer ref = Writer
       MessagePackEncoder.fixmap(wf, arg1.u8())?
-      h.assert_true(compact <= _writer_size(wf),
-        "compact <= fixmap for "
-          + arg1.string())
+      h.assert_true(
+        compact <= _writer_size(wf),
+        "compact <= fixmap for " +
+          arg1.string())
     end
 
   fun _writer_size(w: Writer ref): USize =>
@@ -1886,12 +1906,12 @@ class \nodoc\ _PropertyStr16Roundtrip
     "msgpack/PropertyStr16Roundtrip"
 
   fun gen(): Generator[String] =>
-    Generators.frequency[String]([
-      as WeightedGenerator[String]:
-      (7, Generators.ascii_printable(0, 300))
-      (3, Generators.ascii_printable(
-        301, U16.max_value().usize()))
-    ])
+    Generators.frequency[String](
+      [ as WeightedGenerator[String]:
+        (7, Generators.ascii_printable(0, 300))
+        (3, Generators.ascii_printable(
+          301, U16.max_value().usize()))
+      ])
 
   fun ref property(arg1: String, h: PropertyHelper) ? =>
     let s: String val = arg1.clone()
@@ -2225,11 +2245,11 @@ class \nodoc\ _PropertyExt16Roundtrip
     Generators.map2[U8, USize,
       (U8, Array[U8] val)](
       Generators.u8().filter({(v) => (v, v != 0xFF) }),
-      Generators.frequency[USize]([
-        as WeightedGenerator[USize]:
-        (7, Generators.usize(0, 300))
-        (3, Generators.usize(301, 1000))
-      ]),
+      Generators.frequency[USize](
+        [ as WeightedGenerator[USize]:
+          (7, Generators.usize(0, 300))
+          (3, Generators.usize(301, 1000))
+        ]),
       {(ext_type, len) =>
         (ext_type,
           recover val
@@ -2265,15 +2285,21 @@ class \nodoc\ _TestDecodeStrRejects is UnitTest
 
   fun ref apply(h: TestHelper) =>
     // str_8 rejects str_16 data
-    _rejects[String](h, _FormatName.str_16(),
+    _rejects[String](
+      h,
+      _FormatName.str_16(),
       {(b) ? => MessagePackDecoder.str_8(b)? },
       "str_8 accepted str_16")
     // str_16 rejects str_8 data
-    _rejects[String](h, _FormatName.str_8(),
+    _rejects[String](
+      h,
+      _FormatName.str_8(),
       {(b) ? => MessagePackDecoder.str_16(b)? },
       "str_16 accepted str_8")
     // str_32 rejects str_8 data
-    _rejects[String](h, _FormatName.str_8(),
+    _rejects[String](
+      h,
+      _FormatName.str_8(),
       {(b) ? => MessagePackDecoder.str_32(b)? },
       "str_32 accepted str_8")
 
@@ -2300,17 +2326,20 @@ class \nodoc\ _TestDecodeBinRejects is UnitTest
 
   fun ref apply(h: TestHelper) =>
     // bin_8 rejects bin_16 data
-    _rejects[Array[U8] iso^](h,
+    _rejects[Array[U8] iso^](
+      h,
       _FormatName.bin_16(),
       {(b) ? => MessagePackDecoder.bin_8(b)? },
       "bin_8 accepted bin_16")
     // bin_16 rejects bin_8 data
-    _rejects[Array[U8] iso^](h,
+    _rejects[Array[U8] iso^](
+      h,
       _FormatName.bin_8(),
       {(b) ? => MessagePackDecoder.bin_16(b)? },
       "bin_16 accepted bin_8")
     // bin_32 rejects bin_8 data
-    _rejects[Array[U8] iso^](h,
+    _rejects[Array[U8] iso^](
+      h,
       _FormatName.bin_8(),
       {(b) ? => MessagePackDecoder.bin_32(b)? },
       "bin_32 accepted bin_8")
@@ -2338,29 +2367,34 @@ class \nodoc\ _TestDecodeFixextRejects is UnitTest
 
   fun ref apply(h: TestHelper) =>
     // fixext_1 rejects fixext_2
-    _rejects(h, _FormatName.fixext_2(),
-      {(b) ? =>
-        MessagePackDecoder.fixext_1(b)? },
+    _rejects(
+      h,
+      _FormatName.fixext_2(),
+      {(b) ? => MessagePackDecoder.fixext_1(b)? },
       "fixext_1 accepted fixext_2")
     // fixext_2 rejects fixext_1
-    _rejects(h, _FormatName.fixext_1(),
-      {(b) ? =>
-        MessagePackDecoder.fixext_2(b)? },
+    _rejects(
+      h,
+      _FormatName.fixext_1(),
+      {(b) ? => MessagePackDecoder.fixext_2(b)? },
       "fixext_2 accepted fixext_1")
     // fixext_4 rejects fixext_8
-    _rejects(h, _FormatName.fixext_8(),
-      {(b) ? =>
-        MessagePackDecoder.fixext_4(b)? },
+    _rejects(
+      h,
+      _FormatName.fixext_8(),
+      {(b) ? => MessagePackDecoder.fixext_4(b)? },
       "fixext_4 accepted fixext_8")
     // fixext_8 rejects fixext_16
-    _rejects(h, _FormatName.fixext_16(),
-      {(b) ? =>
-        MessagePackDecoder.fixext_8(b)? },
+    _rejects(
+      h,
+      _FormatName.fixext_16(),
+      {(b) ? => MessagePackDecoder.fixext_8(b)? },
       "fixext_8 accepted fixext_16")
     // fixext_16 rejects fixext_1
-    _rejects(h, _FormatName.fixext_1(),
-      {(b) ? =>
-        MessagePackDecoder.fixext_16(b)? },
+    _rejects(
+      h,
+      _FormatName.fixext_1(),
+      {(b) ? => MessagePackDecoder.fixext_16(b)? },
       "fixext_16 accepted fixext_1")
 
   fun _rejects(
@@ -2386,19 +2420,22 @@ class \nodoc\ _TestDecodeExtRejects is UnitTest
 
   fun ref apply(h: TestHelper) =>
     // ext_8 rejects ext_16
-    _rejects(h, _FormatName.ext_16(),
-      {(b) ? =>
-        MessagePackDecoder.ext_8(b)? },
+    _rejects(
+      h,
+      _FormatName.ext_16(),
+      {(b) ? => MessagePackDecoder.ext_8(b)? },
       "ext_8 accepted ext_16")
     // ext_16 rejects ext_8
-    _rejects(h, _FormatName.ext_8(),
-      {(b) ? =>
-        MessagePackDecoder.ext_16(b)? },
+    _rejects(
+      h,
+      _FormatName.ext_8(),
+      {(b) ? => MessagePackDecoder.ext_16(b)? },
       "ext_16 accepted ext_8")
     // ext_32 rejects ext_8
-    _rejects(h, _FormatName.ext_8(),
-      {(b) ? =>
-        MessagePackDecoder.ext_32(b)? },
+    _rejects(
+      h,
+      _FormatName.ext_8(),
+      {(b) ? => MessagePackDecoder.ext_32(b)? },
       "ext_32 accepted ext_8")
 
   fun _rejects(
@@ -2418,7 +2455,6 @@ class \nodoc\ _TestDecodeExtRejects is UnitTest
 //
 // Skip tests
 //
-
 class \nodoc\ _TestSkipNil is UnitTest
   fun name(): String =>
     "msgpack/SkipNil"
@@ -2450,8 +2486,8 @@ class \nodoc\ _TestSkipBool is UnitTest
       b.append(bs)
     end
     MessagePackDecoder.skip(b)?
-    h.assert_eq[USize](0, b.size(),
-      "skip bool " + v.string())
+    h.assert_eq[USize](
+      0, b.size(), "skip bool " + v.string())
 
 class \nodoc\ _TestSkipFixint is UnitTest
   fun name(): String =>
@@ -2466,8 +2502,8 @@ class \nodoc\ _TestSkipFixint is UnitTest
       b.append(bs)
     end
     MessagePackDecoder.skip(b)?
-    h.assert_eq[USize](0, b.size(),
-      "skip positive fixint")
+    h.assert_eq[USize](
+      0, b.size(), "skip positive fixint")
 
     // negative fixint
     let w2: Writer ref = Writer
@@ -2477,8 +2513,8 @@ class \nodoc\ _TestSkipFixint is UnitTest
       b2.append(bs)
     end
     MessagePackDecoder.skip(b2)?
-    h.assert_eq[USize](0, b2.size(),
-      "skip negative fixint")
+    h.assert_eq[USize](
+      0, b2.size(), "skip negative fixint")
 
 class \nodoc\ _TestSkipUint is UnitTest
   fun name(): String =>
@@ -2488,8 +2524,8 @@ class \nodoc\ _TestSkipUint is UnitTest
     _check(h, 200, 2, "uint_8")?
     _check(h, 1000, 3, "uint_16")?
     _check(h, 100000, 5, "uint_32")?
-    _check(h, (U32.max_value().u64() + 1),
-      9, "uint_64")?
+    _check(
+      h, (U32.max_value().u64() + 1), 9, "uint_64")?
 
   fun _check(
     h: TestHelper,
@@ -2504,11 +2540,11 @@ class \nodoc\ _TestSkipUint is UnitTest
     for bs in w.done().values() do
       b.append(bs)
     end
-    h.assert_eq[USize](expected_size, b.size(),
-      "size " + label)
+    h.assert_eq[USize](
+      expected_size, b.size(), "size " + label)
     MessagePackDecoder.skip(b)?
-    h.assert_eq[USize](0, b.size(),
-      "skip " + label)
+    h.assert_eq[USize](
+      0, b.size(), "skip " + label)
 
 class \nodoc\ _TestSkipInt is UnitTest
   fun name(): String =>
@@ -2518,8 +2554,8 @@ class \nodoc\ _TestSkipInt is UnitTest
     _check(h, -100, 2, "int_8")?
     _check(h, -1000, 3, "int_16")?
     _check(h, -100000, 5, "int_32")?
-    _check(h, I32.min_value().i64() - 1,
-      9, "int_64")?
+    _check(
+      h, I32.min_value().i64() - 1, 9, "int_64")?
 
   fun _check(
     h: TestHelper,
@@ -2534,11 +2570,11 @@ class \nodoc\ _TestSkipInt is UnitTest
     for bs in w.done().values() do
       b.append(bs)
     end
-    h.assert_eq[USize](expected_size, b.size(),
-      "size " + label)
+    h.assert_eq[USize](
+      expected_size, b.size(), "size " + label)
     MessagePackDecoder.skip(b)?
-    h.assert_eq[USize](0, b.size(),
-      "skip " + label)
+    h.assert_eq[USize](
+      0, b.size(), "skip " + label)
 
 class \nodoc\ _TestSkipFloat is UnitTest
   fun name(): String =>
@@ -2586,8 +2622,9 @@ class \nodoc\ _TestSkipStr8 is UnitTest
     "msgpack/SkipStr8"
 
   fun ref apply(h: TestHelper) ? =>
-    let s = String.from_array(
-      recover val Array[U8].init('A', 40) end)
+    let s =
+      String.from_array(
+        recover val Array[U8].init('A', 40) end)
     let w: Writer ref = Writer
     let b: Reader ref = Reader
     MessagePackEncoder.str_8(w, s)?
@@ -2602,8 +2639,9 @@ class \nodoc\ _TestSkipStr16 is UnitTest
     "msgpack/SkipStr16"
 
   fun ref apply(h: TestHelper) ? =>
-    let s = String.from_array(
-      recover val Array[U8].init('A', 300) end)
+    let s =
+      String.from_array(
+        recover val Array[U8].init('A', 300) end)
     let w: Writer ref = Writer
     let b: Reader ref = Reader
     MessagePackEncoder.str_16(w, s)?
@@ -2618,11 +2656,12 @@ class \nodoc\ _TestSkipStr32 is UnitTest
     "msgpack/SkipStr32"
 
   fun ref apply(h: TestHelper) ? =>
-    let s = String.from_array(
-      recover val
-        Array[U8].init('A',
-          U16.max_value().usize() + 1)
-      end)
+    let s =
+      String.from_array(
+        recover val
+          Array[U8].init(
+            'A', U16.max_value().usize() + 1)
+        end)
     let w: Writer ref = Writer
     let b: Reader ref = Reader
     MessagePackEncoder.str_32(w, s)?
@@ -2671,8 +2710,8 @@ class \nodoc\ _TestSkipBin32 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let data: Array[U8] val =
       recover val
-        Array[U8].init(0xFF,
-          U16.max_value().usize() + 1)
+        Array[U8].init(
+          0xFF, U16.max_value().usize() + 1)
       end
     let w: Writer ref = Writer
     let b: Reader ref = Reader
@@ -2712,8 +2751,8 @@ class \nodoc\ _TestSkipFixext is UnitTest
       b.append(bs)
     end
     MessagePackDecoder.skip(b)?
-    h.assert_eq[USize](0, b.size(),
-      "skip " + label)
+    h.assert_eq[USize](
+      0, b.size(), "skip " + label)
 
 class \nodoc\ _TestSkipExt8 is UnitTest
   fun name(): String =>
@@ -2754,8 +2793,8 @@ class \nodoc\ _TestSkipExt32 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let data: Array[U8] val =
       recover val
-        Array[U8].init('X',
-          U16.max_value().usize() + 1)
+        Array[U8].init(
+          'X', U16.max_value().usize() + 1)
       end
     let w: Writer ref = Writer
     let b: Reader ref = Reader
@@ -2786,9 +2825,11 @@ class \nodoc\ _TestSkipTimestamp is UnitTest
       b.append(bs)
     end
     MessagePackDecoder.skip(b)?
-    h.assert_eq[USize](0, b.size(),
-      "skip timestamp sec=" + sec.string()
-        + " nsec=" + nsec.string())
+    h.assert_eq[USize](
+      0,
+      b.size(),
+      "skip timestamp sec=" + sec.string() +
+        " nsec=" + nsec.string())
 
 class \nodoc\ _TestSkipFixarray is UnitTest
   fun name(): String =>
@@ -2935,8 +2976,8 @@ class \nodoc\ _TestSkipEmptyContainers is UnitTest
       b.append(bs)
     end
     MessagePackDecoder.skip(b)?
-    h.assert_eq[USize](0, b.size(),
-      "skip empty array")
+    h.assert_eq[USize](
+      0, b.size(), "skip empty array")
 
     // empty map
     let w2: Writer ref = Writer
@@ -2946,8 +2987,8 @@ class \nodoc\ _TestSkipEmptyContainers is UnitTest
       b2.append(bs)
     end
     MessagePackDecoder.skip(b2)?
-    h.assert_eq[USize](0, b2.size(),
-      "skip empty map")
+    h.assert_eq[USize](
+      0, b2.size(), "skip empty map")
 
 class \nodoc\ _TestSkipPositionPreserving is UnitTest
   fun name(): String =>
@@ -2963,7 +3004,9 @@ class \nodoc\ _TestSkipPositionPreserving is UnitTest
       b.append(bs)
     end
     MessagePackDecoder.skip(b)?
-    h.assert_eq[U64](42, MessagePackDecoder.uint(b)?,
+    h.assert_eq[U64](
+      42,
+      MessagePackDecoder.uint(b)?,
       "skip str then decode uint")
 
     // skip array with contents, decode str
@@ -2979,7 +3022,8 @@ class \nodoc\ _TestSkipPositionPreserving is UnitTest
     MessagePackDecoder.skip(b2)?
     let result = MessagePackDecoder.str(b2)?
     h.assert_eq[String val](
-      "after", consume result,
+      "after",
+      consume result,
       "skip array then decode str")
 
 class \nodoc\ _TestSkipInvalidFormatByte is UnitTest
@@ -3010,7 +3054,9 @@ class \nodoc\ _TestSkipTruncatedData is UnitTest
       MessagePackDecoder.skip(b)?
       h.fail("skip accepted truncated uint_32")
     end
-    h.assert_eq[USize](1, b.size(),
+    h.assert_eq[USize](
+      1,
+      b.size(),
       "truncated header: no bytes consumed")
 
     // truncated str_8 (header + length, no data)
@@ -3023,13 +3069,14 @@ class \nodoc\ _TestSkipTruncatedData is UnitTest
       MessagePackDecoder.skip(b2)?
       h.fail("skip accepted truncated str_8")
     end
-    h.assert_eq[USize](2, b2.size(),
+    h.assert_eq[USize](
+      2,
+      b2.size(),
       "truncated payload: no bytes consumed")
 
 //
 // Skip property tests
 //
-
 class \nodoc\ _PropertySkipUint
   is Property1[U64]
   """
@@ -3040,18 +3087,18 @@ class \nodoc\ _PropertySkipUint
     "msgpack/PropertySkipUint"
 
   fun gen(): Generator[U64] =>
-    Generators.frequency[U64]([
-      as WeightedGenerator[U64]:
-      (2, Generators.u8().map[U64]({(v) =>
-        (v and 0x7F).u64()}))
-      (2, Generators.u8().map[U64]({(v) =>
-        (v or 0x80).u64()}))
-      (2, Generators.u16().map[U64]({(v) =>
-        v.u64() + 256}))
-      (2, Generators.u32().map[U64]({(v) =>
-        v.u64() + 65536}))
-      (2, Generators.u64())
-    ])
+    Generators.frequency[U64](
+      [ as WeightedGenerator[U64]:
+        (2, Generators.u8().map[U64]({(v) =>
+          (v and 0x7F).u64()}))
+        (2, Generators.u8().map[U64]({(v) =>
+          (v or 0x80).u64()}))
+        (2, Generators.u16().map[U64]({(v) =>
+          v.u64() + 256}))
+        (2, Generators.u32().map[U64]({(v) =>
+          v.u64() + 65536}))
+        (2, Generators.u64())
+      ])
 
   fun ref property(arg1: U64, h: PropertyHelper) ? =>
     let w: Writer ref = Writer
@@ -3073,26 +3120,26 @@ class \nodoc\ _PropertySkipInt
     "msgpack/PropertySkipInt"
 
   fun gen(): Generator[I64] =>
-    Generators.frequency[I64]([
-      as WeightedGenerator[I64]:
-      (2, Generators.u8().map[I64]({(v) =>
-        (v and 0x7F).i64()}))
-      (2, Generators.u8().map[I64]({(v) =>
-        -((v % 32).i64() + 1)}))
-      (1, Generators.u8().map[I64]({(v) =>
-        (v or 0x80).i64()}))
-      (1, Generators.u8().map[I64]({(v) =>
-        -((v % 96).i64() + 33)}))
-      (1, Generators.u16().map[I64]({(v) =>
-        v.i64() + 256}))
-      (1, Generators.u16().map[I64]({(v) =>
-        -(v.i64() + 129)}))
-      (1, Generators.u32().map[I64]({(v) =>
-        v.i64() + 65536}))
-      (1, Generators.u32().map[I64]({(v) =>
-        -(v.i64() + 32769)}))
-      (1, Generators.i64())
-    ])
+    Generators.frequency[I64](
+      [ as WeightedGenerator[I64]:
+        (2, Generators.u8().map[I64]({(v) =>
+          (v and 0x7F).i64()}))
+        (2, Generators.u8().map[I64]({(v) =>
+          -((v % 32).i64() + 1)}))
+        (1, Generators.u8().map[I64]({(v) =>
+          (v or 0x80).i64()}))
+        (1, Generators.u8().map[I64]({(v) =>
+          -((v % 96).i64() + 33)}))
+        (1, Generators.u16().map[I64]({(v) =>
+          v.i64() + 256}))
+        (1, Generators.u16().map[I64]({(v) =>
+          -(v.i64() + 129)}))
+        (1, Generators.u32().map[I64]({(v) =>
+          v.i64() + 65536}))
+        (1, Generators.u32().map[I64]({(v) =>
+          -(v.i64() + 32769)}))
+        (1, Generators.i64())
+      ])
 
   fun ref property(arg1: I64, h: PropertyHelper) ? =>
     let w: Writer ref = Writer
@@ -3114,16 +3161,16 @@ class \nodoc\ _PropertySkipStr
     "msgpack/PropertySkipStr"
 
   fun gen(): Generator[String] =>
-    Generators.frequency[String]([
-      as WeightedGenerator[String]:
-      (5, Generators.ascii_printable(
-        0, _Limit.fixstr()))
-      (3, Generators.ascii_printable(
-        _Limit.fixstr() + 1,
-        U8.max_value().usize()))
-      (2, Generators.ascii_printable(
-        U8.max_value().usize() + 1, 300))
-    ])
+    Generators.frequency[String](
+      [ as WeightedGenerator[String]:
+        (5, Generators.ascii_printable(
+          0, _Limit.fixstr()))
+        (3, Generators.ascii_printable(
+          _Limit.fixstr() + 1,
+          U8.max_value().usize()))
+        (2, Generators.ascii_printable(
+          U8.max_value().usize() + 1, 300))
+      ])
 
   fun ref property(arg1: String, h: PropertyHelper) ? =>
     let s: String val = arg1.clone()
@@ -3186,16 +3233,16 @@ class \nodoc\ _PropertySkipExt
       (U8, Array[U8] val)](
       Generators.u8().filter(
         {(v) => (v, v != 0xFF) }),
-      Generators.frequency[USize]([
-        as WeightedGenerator[USize]:
-        (2, Generators.usize(1, 1))
-        (2, Generators.usize(2, 2))
-        (2, Generators.usize(4, 4))
-        (2, Generators.usize(8, 8))
-        (2, Generators.usize(16, 16))
-        (3, Generators.usize(0,
-          U8.max_value().usize()))
-      ]),
+      Generators.frequency[USize](
+        [ as WeightedGenerator[USize]:
+          (2, Generators.usize(1, 1))
+          (2, Generators.usize(2, 2))
+          (2, Generators.usize(4, 4))
+          (2, Generators.usize(8, 8))
+          (2, Generators.usize(16, 16))
+          (3, Generators.usize(
+            0, U8.max_value().usize()))
+        ]),
       {(ext_type, len) =>
         (ext_type,
           recover val
@@ -3247,8 +3294,8 @@ class \nodoc\ _PropertySkipPositionPreserving
       b.append(bs)
     end
     MessagePackDecoder.skip(b)?
-    h.assert_eq[U64](second,
-      MessagePackDecoder.uint(b)?)
+    h.assert_eq[U64](
+      second, MessagePackDecoder.uint(b)?)
 
 class \nodoc\ _TestValidateUTF8Valid is UnitTest
   fun name(): String =>
@@ -3312,8 +3359,8 @@ class \nodoc\ _TestDecodeFixstrUtf8 is UnitTest
     for bs in w.done().values() do
       b.append(bs)
     end
-    h.assert_eq[String]("hello",
-      MessagePackDecoder.fixstr_utf8(b)?)
+    h.assert_eq[String](
+      "hello", MessagePackDecoder.fixstr_utf8(b)?)
 
 class \nodoc\ _TestDecodeFixstrUtf8Invalid is UnitTest
   fun name(): String =>
@@ -3343,8 +3390,8 @@ class \nodoc\ _TestDecodeStr8Utf8 is UnitTest
     for bs in w.done().values() do
       b.append(bs)
     end
-    h.assert_eq[String]("str8",
-      MessagePackDecoder.str_8_utf8(b)?)
+    h.assert_eq[String](
+      "str8", MessagePackDecoder.str_8_utf8(b)?)
 
 class \nodoc\ _TestDecodeStr8Utf8Invalid is UnitTest
   fun name(): String =>
@@ -3374,8 +3421,8 @@ class \nodoc\ _TestDecodeStr16Utf8 is UnitTest
     for bs in w.done().values() do
       b.append(bs)
     end
-    h.assert_eq[String]("str16",
-      MessagePackDecoder.str_16_utf8(b)?)
+    h.assert_eq[String](
+      "str16", MessagePackDecoder.str_16_utf8(b)?)
 
 class \nodoc\ _TestDecodeStr16Utf8Invalid is UnitTest
   fun name(): String =>
@@ -3405,8 +3452,8 @@ class \nodoc\ _TestDecodeStr32Utf8 is UnitTest
     for bs in w.done().values() do
       b.append(bs)
     end
-    h.assert_eq[String]("str32",
-      MessagePackDecoder.str_32_utf8(b)?)
+    h.assert_eq[String](
+      "str32", MessagePackDecoder.str_32_utf8(b)?)
 
 class \nodoc\ _TestDecodeStr32Utf8Invalid is UnitTest
   fun name(): String =>
@@ -3436,8 +3483,8 @@ class \nodoc\ _TestDecodeCompactStrUtf8 is UnitTest
     for bs in w.done().values() do
       b.append(bs)
     end
-    h.assert_eq[String]("hello",
-      MessagePackDecoder.str_utf8(b)?)
+    h.assert_eq[String](
+      "hello", MessagePackDecoder.str_utf8(b)?)
 
 class \nodoc\ _TestDecodeCompactStrUtf8Invalid is UnitTest
   fun name(): String =>
@@ -3467,16 +3514,16 @@ class \nodoc\ _PropertyCompactStrUtf8Roundtrip
     "msgpack/PropertyCompactStrUtf8Roundtrip"
 
   fun gen(): Generator[String] =>
-    Generators.frequency[String]([
-      as WeightedGenerator[String]:
-      (5, Generators.ascii_printable(
-        0, _Limit.fixstr()))
-      (3, Generators.ascii_printable(
-        _Limit.fixstr() + 1,
-        U8.max_value().usize()))
-      (2, Generators.ascii_printable(
-        U8.max_value().usize() + 1, 300))
-    ])
+    Generators.frequency[String](
+      [ as WeightedGenerator[String]:
+        (5, Generators.ascii_printable(
+          0, _Limit.fixstr()))
+        (3, Generators.ascii_printable(
+          _Limit.fixstr() + 1,
+          U8.max_value().usize()))
+        (2, Generators.ascii_printable(
+          U8.max_value().usize() + 1, 300))
+      ])
 
   fun ref property(arg1: String, h: PropertyHelper) ? =>
     let s: String val = arg1.clone()

--- a/msgpack/_test_encoder.pony
+++ b/msgpack/_test_encoder.pony
@@ -1,21 +1,3 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 use "buffered"
 use "collections"
 use "pony_check"
@@ -23,7 +5,9 @@ use "pony_test"
 
 actor \nodoc\ _TestEncoder is TestList
   """
-  These tests include information from the [MessagePack specification](https://github.com/msgpack/msgpack/blob/master/spec.md).
+  These tests include information from the
+  [MessagePack specification](
+  https://github.com/msgpack/msgpack/blob/master/spec.md).
 
   ### Notation in test diagrams.
 
@@ -371,9 +355,12 @@ class \nodoc\ _TestEncodeUint32 is UnitTest
 class \nodoc\ _TestEncodeUint64 is UnitTest
   """
   uint 64 stores a 64-bit big-endian unsigned integer
-  +--------+--------+--------+--------+--------+--------+--------+--------+--------+
-  |  0xcf  |ZZZZZZZZ|ZZZZZZZZ|ZZZZZZZZ|ZZZZZZZZ|ZZZZZZZZ|ZZZZZZZZ|ZZZZZZZZ|ZZZZZZZZ|
-  +--------+--------+--------+--------+--------+--------+--------+--------+--------+
+
+  ```
+  +------+------+------+------+------+------+------+------+------+
+  | 0xcf | ZZZZ | ZZZZ | ZZZZ | ZZZZ | ZZZZ | ZZZZ | ZZZZ | ZZZZ |
+  +------+------+------+------+------+------+------+------+------+
+  ```
   """
   fun name(): String =>
     "msgpack/EncodeUint64"
@@ -471,9 +458,12 @@ class \nodoc\ _TestEncodeInt32 is UnitTest
 class \nodoc\ _TestEncodeInt64 is UnitTest
   """
   int 64 stores a 64-bit big-endian signed integer
-  +--------+--------+--------+--------+--------+--------+--------+--------+--------+
-  |  0xd3  |ZZZZZZZZ|ZZZZZZZZ|ZZZZZZZZ|ZZZZZZZZ|ZZZZZZZZ|ZZZZZZZZ|ZZZZZZZZ|ZZZZZZZZ|
-  +--------+--------+--------+--------+--------+--------+--------+--------+--------+
+
+  ```
+  +------+------+------+------+------+------+------+------+------+
+  | 0xd3 | ZZZZ | ZZZZ | ZZZZ | ZZZZ | ZZZZ | ZZZZ | ZZZZ | ZZZZ |
+  +------+------+------+------+------+------+------+------+------+
+  ```
   """
   fun name(): String =>
     "msgpack/EncodeInt64"
@@ -521,11 +511,14 @@ class \nodoc\ _TestEncodeFloat32 is UnitTest
 
 class \nodoc\ _TestEncodeFloat64 is UnitTest
   """
-  float 64 stores a floating point number in IEEE 754 double precision
-  floating point number format:
-  +--------+--------+--------+--------+--------+--------+--------+--------+--------+
-  |  0xcb  |YYYYYYYY|YYYYYYYY|YYYYYYYY|YYYYYYYY|YYYYYYYY|YYYYYYYY|YYYYYYYY|YYYYYYYY|
-  +--------+--------+--------+--------+--------+--------+--------+--------+--------+
+  float 64 stores a floating point number in IEEE 754 double
+  precision floating point number format:
+
+  ```
+  +------+------+------+------+------+------+------+------+------+
+  | 0xcb | YYYY | YYYY | YYYY | YYYY | YYYY | YYYY | YYYY | YYYY |
+  +------+------+------+------+------+------+------+------+------+
+  ```
   """
   fun name(): String =>
     "msgpack/EncodeFloat64"
@@ -1602,8 +1595,8 @@ class \nodoc\ _TestEncodeTimestamp96 is UnitTest
 
 class \nodoc\ _TestEncodeTimestamp96NsecsTooLarge is UnitTest
   """
-  Verify that `timestamp_96` throws an error if supplied a nanoseconds value larger
-  than 99999999.
+  Verify that `timestamp_96` throws an error if supplied a
+  nanoseconds value larger than 99999999.
   """
   fun name(): String =>
     "msgpack/EncodeTimestamp96NsecsTooLarge"
@@ -1632,12 +1625,24 @@ class \nodoc\ _TestEncodeCompactUint is UnitTest
     _check(h, 256, 3, _FormatName.uint_16())?    // uint_16 min
     _check(h, 65535, 3, _FormatName.uint_16())?  // uint_16 max
     _check(h, 65536, 5, _FormatName.uint_32())?  // uint_32 min
-    _check(h, U32.max_value().u64(), 5,
-      _FormatName.uint_32())?                    // uint_32 max
-    _check(h, U32.max_value().u64() + 1, 9,
-      _FormatName.uint_64())?                    // uint_64 min
-    _check(h, U64.max_value(), 9,
-      _FormatName.uint_64())?                    // uint_64 max
+    // uint_32 max
+    _check(
+      h,
+      U32.max_value().u64(),
+      5,
+      _FormatName.uint_32())?
+    // uint_64 min
+    _check(
+      h,
+      U32.max_value().u64() + 1,
+      9,
+      _FormatName.uint_64())?
+    // uint_64 max
+    _check(
+      h,
+      U64.max_value(),
+      9,
+      _FormatName.uint_64())?
 
   fun _check(
     h: TestHelper,
@@ -1655,9 +1660,13 @@ class \nodoc\ _TestEncodeCompactUint is UnitTest
       b.append(bs)
     end
 
-    h.assert_eq[USize](expected_size, b.size(),
+    h.assert_eq[USize](
+      expected_size,
+      b.size(),
       "size for " + v.string())
-    h.assert_eq[U8](expected_format, b.peek_u8()?,
+    h.assert_eq[U8](
+      expected_format,
+      b.peek_u8()?,
       "format for " + v.string())
 
 class \nodoc\ _TestEncodeCompactInt is UnitTest
@@ -1690,10 +1699,16 @@ class \nodoc\ _TestEncodeCompactInt is UnitTest
     // int_32
     _check(h, -32769, 5, _FormatName.int_32())?
     // uint_64
-    _check(h, U32.max_value().i64() + 1, 9,
+    _check(
+      h,
+      U32.max_value().i64() + 1,
+      9,
       _FormatName.uint_64())?
     // int_64
-    _check(h, I64.min_value(), 9,
+    _check(
+      h,
+      I64.min_value(),
+      9,
       _FormatName.int_64())?
 
   fun _check(
@@ -1712,9 +1727,13 @@ class \nodoc\ _TestEncodeCompactInt is UnitTest
       b.append(bs)
     end
 
-    h.assert_eq[USize](expected_size, b.size(),
+    h.assert_eq[USize](
+      expected_size,
+      b.size(),
       "size for " + v.string())
-    h.assert_eq[U8](expected_format, b.peek_u8()?,
+    h.assert_eq[U8](
+      expected_format,
+      b.peek_u8()?,
       "format for " + v.string())
 
 class \nodoc\ _TestEncodeCompactStr is UnitTest
@@ -1727,31 +1746,30 @@ class \nodoc\ _TestEncodeCompactStr is UnitTest
   fun ref apply(h: TestHelper) ? =>
     // fixstr boundaries
     let empty = recover val Array[U8] end
-    _check(h, empty, 1, 0xA0)?                  // 0: fixstr
-    let fix5 = recover val
-      Array[U8].init('A', 5)
-    end
-    _check(h, fix5, 6, 0xA5)?                   // 5: fixstr
-    let fix31 = recover val
-      Array[U8].init('A', 31)
-    end
-    _check(h, fix31, 32, 0xBF)?                  // 31: fixstr max
+    _check(h, empty, 1, 0xA0)?
+    let fix5 =
+      recover val Array[U8].init('A', 5) end
+    _check(h, fix5, 6, 0xA5)?
+    let fix31 =
+      recover val Array[U8].init('A', 31) end
+    _check(h, fix31, 32, 0xBF)?
 
     // str_8 boundaries
-    let s8_32 = recover val
-      Array[U8].init('B', 32)
-    end
-    _check(h, s8_32, 34, _FormatName.str_8())?   // 32: str_8 min
-    let s8_255 = recover val
-      Array[U8].init('B', 255)
-    end
-    _check(h, s8_255, 257, _FormatName.str_8())? // 255: str_8 max
+    let s8_32 =
+      recover val Array[U8].init('B', 32) end
+    _check(h, s8_32, 34, _FormatName.str_8())?
+    let s8_255 =
+      recover val Array[U8].init('B', 255) end
+    _check(h, s8_255, 257, _FormatName.str_8())?
 
     // str_16 boundary
-    let s16_256 = recover val
-      Array[U8].init('C', 256)
-    end
-    _check(h, s16_256, 259, _FormatName.str_16())? // 256: str_16 min
+    let s16_256 =
+      recover val Array[U8].init('C', 256) end
+    _check(
+      h,
+      s16_256,
+      259,
+      _FormatName.str_16())?
 
   fun _check(
     h: TestHelper,
@@ -1769,9 +1787,13 @@ class \nodoc\ _TestEncodeCompactStr is UnitTest
       b.append(bs)
     end
 
-    h.assert_eq[USize](expected_size, b.size(),
+    h.assert_eq[USize](
+      expected_size,
+      b.size(),
       "size for len=" + v.size().string())
-    h.assert_eq[U8](expected_format, b.peek_u8()?,
+    h.assert_eq[U8](
+      expected_format,
+      b.peek_u8()?,
       "format for len=" + v.size().string())
 
 class \nodoc\ _TestEncodeCompactBin is UnitTest
@@ -1784,21 +1806,22 @@ class \nodoc\ _TestEncodeCompactBin is UnitTest
   fun ref apply(h: TestHelper) ? =>
     // bin_8 boundaries
     let empty = recover val Array[U8] end
-    _check(h, empty, 2, _FormatName.bin_8())?     // 0: bin_8 min
-    let b8_5 = recover val
-      Array[U8].init('A', 5)
-    end
-    _check(h, b8_5, 7, _FormatName.bin_8())?      // 5: bin_8
-    let b8_255 = recover val
-      Array[U8].init('A', 255)
-    end
-    _check(h, b8_255, 257, _FormatName.bin_8())?  // 255: bin_8 max
+    _check(h, empty, 2, _FormatName.bin_8())?
+    let b8_5 =
+      recover val Array[U8].init('A', 5) end
+    _check(h, b8_5, 7, _FormatName.bin_8())?
+    let b8_255 =
+      recover val Array[U8].init('A', 255) end
+    _check(h, b8_255, 257, _FormatName.bin_8())?
 
     // bin_16 boundary
-    let b16_256 = recover val
-      Array[U8].init('B', 256)
-    end
-    _check(h, b16_256, 259, _FormatName.bin_16())? // 256: bin_16 min
+    let b16_256 =
+      recover val Array[U8].init('B', 256) end
+    _check(
+      h,
+      b16_256,
+      259,
+      _FormatName.bin_16())?
 
   fun _check(
     h: TestHelper,
@@ -1816,9 +1839,13 @@ class \nodoc\ _TestEncodeCompactBin is UnitTest
       b.append(bs)
     end
 
-    h.assert_eq[USize](expected_size, b.size(),
+    h.assert_eq[USize](
+      expected_size,
+      b.size(),
       "size for len=" + v.size().string())
-    h.assert_eq[U8](expected_format, b.peek_u8()?,
+    h.assert_eq[U8](
+      expected_format,
+      b.peek_u8()?,
       "format for len=" + v.size().string())
 
 class \nodoc\ _TestEncodeCompactArray is UnitTest
@@ -1855,9 +1882,13 @@ class \nodoc\ _TestEncodeCompactArray is UnitTest
       b.append(bs)
     end
 
-    h.assert_eq[USize](expected_size, b.size(),
+    h.assert_eq[USize](
+      expected_size,
+      b.size(),
       "size for " + s.string())
-    h.assert_eq[U8](expected_format, b.peek_u8()?,
+    h.assert_eq[U8](
+      expected_format,
+      b.peek_u8()?,
       "format for " + s.string())
 
 class \nodoc\ _TestEncodeCompactMap is UnitTest
@@ -1894,9 +1925,13 @@ class \nodoc\ _TestEncodeCompactMap is UnitTest
       b.append(bs)
     end
 
-    h.assert_eq[USize](expected_size, b.size(),
+    h.assert_eq[USize](
+      expected_size,
+      b.size(),
       "size for " + s.string())
-    h.assert_eq[U8](expected_format, b.peek_u8()?,
+    h.assert_eq[U8](
+      expected_format,
+      b.peek_u8()?,
       "format for " + s.string())
 
 class \nodoc\ _TestEncodeCompactExt is UnitTest
@@ -1926,9 +1961,8 @@ class \nodoc\ _TestEncodeCompactExt is UnitTest
     expected_format: U8)
     ?
   =>
-    let value = recover val
-      Array[U8].init('X', data_size)
-    end
+    let value =
+      recover val Array[U8].init('X', data_size) end
     let w: Writer ref = Writer
     let b = Reader
 
@@ -1938,7 +1972,9 @@ class \nodoc\ _TestEncodeCompactExt is UnitTest
       b.append(bs)
     end
 
-    h.assert_eq[U8](expected_format, b.peek_u8()?,
+    h.assert_eq[U8](
+      expected_format,
+      b.peek_u8()?,
       "format for size=" + data_size.string())
 
 class \nodoc\ _TestEncodeCompactTimestamp is UnitTest
@@ -1950,34 +1986,62 @@ class \nodoc\ _TestEncodeCompactTimestamp is UnitTest
 
   fun ref apply(h: TestHelper) ? =>
     // timestamp_32 boundaries
-    _check(h, 0, 0, _FormatName.fixext_4(),
+    _check(
+      h,
+      0,
+      0,
+      _FormatName.fixext_4(),
       "ts32: sec=0 nsec=0")?
-    _check(h, 500, 0, _FormatName.fixext_4(),
+    _check(
+      h,
+      500,
+      0,
+      _FormatName.fixext_4(),
       "ts32: sec=500 nsec=0")?
-    _check(h, U32.max_value().i64(), 0,
+    _check(
+      h,
+      U32.max_value().i64(),
+      0,
       _FormatName.fixext_4(),
       "ts32: sec=U32.max nsec=0")?
 
     // timestamp_64 boundaries
     // nsec != 0 pushes to timestamp_64
-    _check(h, 500, 100, _FormatName.fixext_8(),
+    _check(
+      h,
+      500,
+      100,
+      _FormatName.fixext_8(),
       "ts64: sec=500 nsec=100")?
-    // sec > U32.max pushes to timestamp_64 even with nsec=0
-    _check(h, U32.max_value().i64() + 1, 0,
+    // sec > U32.max pushes to timestamp_64
+    _check(
+      h,
+      U32.max_value().i64() + 1,
+      0,
       _FormatName.fixext_8(),
       "ts64: sec=U32.max+1 nsec=0")?
     // sec at 34-bit max
-    _check(h, _Limit.sec_34().i64(), 0,
+    _check(
+      h,
+      _Limit.sec_34().i64(),
+      0,
       _FormatName.fixext_8(),
       "ts64: sec=2^34-1 nsec=0")?
 
     // timestamp_96 boundaries
     // sec exceeds 34-bit max
-    _check(h, _Limit.sec_34().i64() + 1, 0,
+    _check(
+      h,
+      _Limit.sec_34().i64() + 1,
+      0,
       _FormatName.ext_8(),
       "ts96: sec=2^34 nsec=0")?
     // negative sec
-    _check(h, -1000, 500, _FormatName.ext_8(),
+    _check(
+      h,
+      -1000,
+      500,
+      _FormatName.ext_8(),
       "ts96: sec=-1000 nsec=500")?
 
   fun _check(
@@ -1994,8 +2058,8 @@ class \nodoc\ _TestEncodeCompactTimestamp is UnitTest
     for bs in w.done().values() do
       b.append(bs)
     end
-    h.assert_eq[U8](expected_format, b.peek_u8()?,
-      label)
+    h.assert_eq[U8](
+      expected_format, b.peek_u8()?, label)
 
 class \nodoc\ _TestEncodeFixstrUtf8 is UnitTest
   fun name(): String =>
@@ -2168,16 +2232,16 @@ class \nodoc\ _PropertyCompactStrUtf8EncoderRoundtrip
     "msgpack/PropertyCompactStrUtf8EncoderRoundtrip"
 
   fun gen(): Generator[String] =>
-    Generators.frequency[String]([
-      as WeightedGenerator[String]:
-      (5, Generators.ascii_printable(
-        0, _Limit.fixstr()))
-      (3, Generators.ascii_printable(
-        _Limit.fixstr() + 1,
-        U8.max_value().usize()))
-      (2, Generators.ascii_printable(
-        U8.max_value().usize() + 1, 300))
-    ])
+    Generators.frequency[String](
+      [ as WeightedGenerator[String]:
+        (5, Generators.ascii_printable(
+          0, _Limit.fixstr()))
+        (3, Generators.ascii_printable(
+          _Limit.fixstr() + 1,
+          U8.max_value().usize()))
+        (2, Generators.ascii_printable(
+          U8.max_value().usize() + 1, 300))
+      ])
 
   fun ref property(arg1: String, h: PropertyHelper) ? =>
     let s: String val = arg1.clone()

--- a/msgpack/_test_streaming_decoder.pony
+++ b/msgpack/_test_streaming_decoder.pony
@@ -1,21 +1,3 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 use "buffered"
 use "pony_check"
 use "pony_test"
@@ -27,7 +9,7 @@ primitive _WriterBytes
   fun apply(w: Writer ref): Array[U8] val =>
     let out = recover iso Array[U8] end
     for chunk in w.done().values() do
-      match chunk
+      match \exhaustive\ chunk
       | let a: Array[U8] val => out.append(a)
       | let s: String val => out.append(s.array())
       end
@@ -185,7 +167,6 @@ actor \nodoc\ _TestStreamingDecoder is TestList
 //
 // Roundtrip tests
 //
-
 class \nodoc\ _TestStreamDecodeNil is UnitTest
   fun name(): String => "msgpack/StreamDecodeNil"
 
@@ -706,7 +687,6 @@ class \nodoc\ _TestStreamDecodeExt32 is UnitTest
 //
 // Streaming-specific tests
 //
-
 class \nodoc\ _TestStreamEmptyReturnsNotEnoughData is UnitTest
   fun name(): String => "msgpack/StreamEmptyReturnsNotEnoughData"
 
@@ -1026,7 +1006,6 @@ class \nodoc\ _TestStreamPartialThenMultiple is UnitTest
 //
 // Timestamp tests
 //
-
 class \nodoc\ _TestStreamTimestamp32 is UnitTest
   fun name(): String => "msgpack/StreamTimestamp32"
 
@@ -1097,8 +1076,8 @@ class \nodoc\ _TestStreamTimestampPartial is UnitTest
       | NotEnoughData => None
       else
         h.fail(
-          "expected NotEnoughData at byte "
-            + i.string())
+          "expected NotEnoughData at byte " +
+            i.string())
         return
       end
       i = i + 1
@@ -1137,8 +1116,8 @@ class \nodoc\ _TestStreamTimestamp64Partial is UnitTest
       | NotEnoughData => None
       else
         h.fail(
-          "expected NotEnoughData at byte "
-            + i.string())
+          "expected NotEnoughData at byte " +
+            i.string())
         return
       end
       i = i + 1
@@ -1177,8 +1156,8 @@ class \nodoc\ _TestStreamTimestamp96Partial is UnitTest
       | NotEnoughData => None
       else
         h.fail(
-          "expected NotEnoughData at byte "
-            + i.string())
+          "expected NotEnoughData at byte " +
+            i.string())
         return
       end
       i = i + 1
@@ -1219,7 +1198,6 @@ class \nodoc\ _TestStreamExt8NotTimestamp is UnitTest
 //
 // Property-based tests
 //
-
 class \nodoc\ _PropertyStreamU32Safety is Property1[U32]
   """
   For any U32, encoding as uint_32 and feeding to the streaming
@@ -1246,8 +1224,8 @@ class \nodoc\ _PropertyStreamU32Safety is Property1[U32]
       | NotEnoughData => None
       else
         h.fail(
-          "NotEnoughData expected at byte "
-            + i.string())
+          "NotEnoughData expected at byte " +
+            i.string())
         return
       end
       i = i + 1
@@ -1291,8 +1269,8 @@ class \nodoc\ _PropertyStreamI16Safety is Property1[I16]
       | NotEnoughData => None
       else
         h.fail(
-          "NotEnoughData expected at byte "
-            + i.string())
+          "NotEnoughData expected at byte " +
+            i.string())
         return
       end
       i = i + 1
@@ -1337,8 +1315,8 @@ class \nodoc\ _PropertyStreamStr8Safety is Property1[String]
       | NotEnoughData => None
       else
         h.fail(
-          "NotEnoughData expected at byte "
-            + i.string())
+          "NotEnoughData expected at byte " +
+            i.string())
         return
       end
       i = i + 1
@@ -1383,8 +1361,8 @@ class \nodoc\ _PropertyStreamTimestamp32Safety
       | NotEnoughData => None
       else
         h.fail(
-          "NotEnoughData expected at byte "
-            + i.string())
+          "NotEnoughData expected at byte " +
+            i.string())
         return
       end
       i = i + 1
@@ -1417,9 +1395,8 @@ class \nodoc\ _PropertyStreamBin16Safety is Property1[U8]
     Generators.u8()
 
   fun ref property(arg1: U8, h: PropertyHelper) ? =>
-    let data = recover val
-      Array[U8].init('X', arg1.usize())
-    end
+    let data =
+      recover val Array[U8].init('X', arg1.usize()) end
     let w: Writer ref = Writer
     MessagePackEncoder.bin_16(w, data)?
     let bytes = _WriterBytes(w)
@@ -1433,8 +1410,8 @@ class \nodoc\ _PropertyStreamBin16Safety is Property1[U8]
       | NotEnoughData => None
       else
         h.fail(
-          "NotEnoughData expected at byte "
-            + i.string())
+          "NotEnoughData expected at byte " +
+            i.string())
         return
       end
       i = i + 1
@@ -1481,8 +1458,8 @@ class \nodoc\ _PropertyStreamStr32Safety
       | NotEnoughData => None
       else
         h.fail(
-          "NotEnoughData expected at byte "
-            + i.string())
+          "NotEnoughData expected at byte " +
+            i.string())
         return
       end
       i = i + 1
@@ -1533,8 +1510,8 @@ class \nodoc\ _PropertyStreamFixext4Safety is Property1[U8]
       | NotEnoughData => None
       else
         h.fail(
-          "NotEnoughData expected at byte "
-            + i.string())
+          "NotEnoughData expected at byte " +
+            i.string())
         return
       end
       i = i + 1
@@ -1565,7 +1542,6 @@ class \nodoc\ _PropertyStreamFixext4Safety is Property1[U8]
 //
 // Limit tests
 //
-
 class \nodoc\ _TestStreamLimitFixext is UnitTest
   """
   A fixext_16 (16 bytes data) is rejected when max_ext_len is 15.
@@ -1576,8 +1552,9 @@ class \nodoc\ _TestStreamLimitFixext is UnitTest
     let w: Writer ref = Writer
     let value = recover val Array[U8].init('V', 16) end
     MessagePackEncoder.fixext_16(w, 40, value)?
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(where max_ext_len' = 15))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(where max_ext_len' = 15))
     sd.append(_WriterBytes(w))
     match sd.next()
     | LimitExceeded => None
@@ -1593,8 +1570,9 @@ class \nodoc\ _TestStreamLimitMap is UnitTest
   fun ref apply(h: TestHelper) =>
     let w: Writer ref = Writer
     MessagePackEncoder.map_16(w, 100)
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(where max_map_len' = 99))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(where max_map_len' = 99))
     sd.append(_WriterBytes(w))
     match sd.next()
     | LimitExceeded => None
@@ -1611,9 +1589,10 @@ class \nodoc\ _TestStreamLimitArray32 is UnitTest
   fun ref apply(h: TestHelper) =>
     let w: Writer ref = Writer
     MessagePackEncoder.array_32(w, 200_000)
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_array_len' = 131_072))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_array_len' = 131_072))
     sd.append(_WriterBytes(w))
     match sd.next()
     | LimitExceeded => None
@@ -1630,9 +1609,10 @@ class \nodoc\ _TestStreamLimitMap32 is UnitTest
   fun ref apply(h: TestHelper) =>
     let w: Writer ref = Writer
     MessagePackEncoder.map_32(w, 200_000)
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_map_len' = 131_072))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_map_len' = 131_072))
     sd.append(_WriterBytes(w))
     match sd.next()
     | LimitExceeded => None
@@ -1652,9 +1632,10 @@ class \nodoc\ _TestStreamLimitStr16 is UnitTest
       String.from_iso_array(consume data)
     let w: Writer ref = Writer
     MessagePackEncoder.str_16(w, s)?
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_str_len' = 250))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_str_len' = 250))
     sd.append(_WriterBytes(w))
     match sd.next()
     | LimitExceeded => None
@@ -1669,14 +1650,16 @@ class \nodoc\ _TestStreamLimitBin16 is UnitTest
   fun name(): String => "msgpack/StreamLimitBin16"
 
   fun ref apply(h: TestHelper) ? =>
-    let data = recover val
-      Array[U8].init('B', 300)
-    end
+    let data =
+      recover val
+        Array[U8].init('B', 300)
+      end
     let w: Writer ref = Writer
     MessagePackEncoder.bin_16(w, data)?
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_bin_len' = 250))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_bin_len' = 250))
     sd.append(_WriterBytes(w))
     match sd.next()
     | LimitExceeded => None
@@ -1691,14 +1674,16 @@ class \nodoc\ _TestStreamLimitExt16 is UnitTest
   fun name(): String => "msgpack/StreamLimitExt16"
 
   fun ref apply(h: TestHelper) ? =>
-    let data = recover val
-      Array[U8].init('C', 300)
-    end
+    let data =
+      recover val
+        Array[U8].init('C', 300)
+      end
     let w: Writer ref = Writer
     MessagePackEncoder.ext_16(w, 42, data)?
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_ext_len' = 250))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_ext_len' = 250))
     sd.append(_WriterBytes(w))
     match sd.next()
     | LimitExceeded => None
@@ -1716,8 +1701,9 @@ class \nodoc\ _TestStreamLimitNoConsume is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.str_8(w, "hello world")?
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(where max_str_len' = 5))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(where max_str_len' = 5))
     sd.append(_WriterBytes(w))
 
     // First call: LimitExceeded
@@ -1743,8 +1729,9 @@ class \nodoc\ _TestStreamLimitUnlimited is UnitTest
   fun ref apply(h: TestHelper) =>
     let w: Writer ref = Writer
     MessagePackEncoder.array_32(w, 200_000)
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits.unlimited())
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits.unlimited())
     sd.append(_WriterBytes(w))
     match sd.next()
     | let v: MessagePackArray =>
@@ -1761,8 +1748,9 @@ class \nodoc\ _TestStreamLimitAtBoundary is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.str_8(w, "1234567890")?
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(where max_str_len' = 10))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(where max_str_len' = 10))
     sd.append(_WriterBytes(w))
     match sd.next()
     | let v: String val =>
@@ -1773,7 +1761,6 @@ class \nodoc\ _TestStreamLimitAtBoundary is UnitTest
 //
 // Limit property-based tests
 //
-
 class \nodoc\ _PropertyStreamLimitStr
   is Property1[String]
   """
@@ -1791,9 +1778,10 @@ class \nodoc\ _PropertyStreamLimitStr
     let s: String val = arg1.clone()
     let w: Writer ref = Writer
     MessagePackEncoder.str(w, s)?
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_str_len' = 50))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_str_len' = 50))
     sd.append(_WriterBytes(w))
 
     if s.size() > 50 then
@@ -1801,8 +1789,8 @@ class \nodoc\ _PropertyStreamLimitStr
       | LimitExceeded => None
       else
         h.fail(
-          "expected LimitExceeded for size "
-            + s.size().string())
+          "expected LimitExceeded for size " +
+            s.size().string())
       end
     else
       match sd.next()
@@ -1810,8 +1798,8 @@ class \nodoc\ _PropertyStreamLimitStr
         h.assert_eq[String](s, v)
       else
         h.fail(
-          "expected String for size "
-            + s.size().string())
+          "expected String for size " +
+            s.size().string())
       end
     end
 
@@ -1828,14 +1816,14 @@ class \nodoc\ _PropertyStreamLimitBin
     Generators.u8()
 
   fun ref property(arg1: U8, h: PropertyHelper) ? =>
-    let data = recover val
-      Array[U8].init('X', arg1.usize())
-    end
+    let data =
+      recover val Array[U8].init('X', arg1.usize()) end
     let w: Writer ref = Writer
     MessagePackEncoder.bin(w, data)?
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_bin_len' = 100))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_bin_len' = 100))
     sd.append(_WriterBytes(w))
 
     if arg1.usize() > 100 then
@@ -1843,8 +1831,8 @@ class \nodoc\ _PropertyStreamLimitBin
       | LimitExceeded => None
       else
         h.fail(
-          "expected LimitExceeded for size "
-            + arg1.string())
+          "expected LimitExceeded for size " +
+            arg1.string())
       end
     else
       match sd.next()
@@ -1853,8 +1841,8 @@ class \nodoc\ _PropertyStreamLimitBin
           arg1.usize(), v.size())
       else
         h.fail(
-          "expected Array[U8] for size "
-            + arg1.string())
+          "expected Array[U8] for size " +
+            arg1.string())
       end
     end
 
@@ -1874,9 +1862,10 @@ class \nodoc\ _PropertyStreamLimitArray
   fun ref property(arg1: U16, h: PropertyHelper) =>
     let w: Writer ref = Writer
     MessagePackEncoder.array(w, arg1.u32())
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_array_len' = 1000))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_array_len' = 1000))
     sd.append(_WriterBytes(w))
 
     if arg1.u32() > 1000 then
@@ -1884,8 +1873,8 @@ class \nodoc\ _PropertyStreamLimitArray
       | LimitExceeded => None
       else
         h.fail(
-          "expected LimitExceeded for count "
-            + arg1.string())
+          "expected LimitExceeded for count " +
+            arg1.string())
       end
     else
       match sd.next()
@@ -1893,8 +1882,8 @@ class \nodoc\ _PropertyStreamLimitArray
         h.assert_eq[U32](arg1.u32(), v.size)
       else
         h.fail(
-          "expected MessagePackArray for count "
-            + arg1.string())
+          "expected MessagePackArray for count " +
+            arg1.string())
       end
     end
 
@@ -1912,14 +1901,16 @@ class \nodoc\ _PropertyStreamLimitExt
     Generators.u8()
 
   fun ref property(arg1: U8, h: PropertyHelper) ? =>
-    let data = recover val
-      Array[U8].init('Z', arg1.usize())
-    end
+    let data =
+      recover val
+        Array[U8].init('Z', arg1.usize())
+      end
     let w: Writer ref = Writer
     MessagePackEncoder.ext(w, 42, data)?
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_ext_len' = 100))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_ext_len' = 100))
     sd.append(_WriterBytes(w))
 
     if arg1.usize() > 100 then
@@ -1927,8 +1918,8 @@ class \nodoc\ _PropertyStreamLimitExt
       | LimitExceeded => None
       else
         h.fail(
-          "expected LimitExceeded for size "
-            + arg1.string())
+          "expected LimitExceeded for size " +
+            arg1.string())
       end
     else
       match sd.next()
@@ -1938,15 +1929,14 @@ class \nodoc\ _PropertyStreamLimitExt
           arg1.usize(), v.data.size())
       else
         h.fail(
-          "expected MessagePackExt for size "
-            + arg1.string())
+          "expected MessagePackExt for size " +
+            arg1.string())
       end
     end
 
 //
 // Depth limit tests
 //
-
 class \nodoc\ _TestStreamDepthBasic is UnitTest
   """
   Nested arrays at depth 2 succeed with max_depth=2.
@@ -1961,9 +1951,10 @@ class \nodoc\ _TestStreamDepthBasic is UnitTest
     MessagePackEncoder.fixarray(w, 1)?
     MessagePackEncoder.uint(w, 1)
 
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_depth' = 2))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_depth' = 2))
     sd.append(_WriterBytes(w))
 
     // Outer array at depth 1 — succeeds
@@ -1994,9 +1985,10 @@ class \nodoc\ _TestStreamDepthBasic is UnitTest
     MessagePackEncoder.fixarray(w2, 1)?
     MessagePackEncoder.uint(w2, 1)
 
-    let sd2 = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_depth' = 2))
+    let sd2 =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_depth' = 2))
     sd2.append(_WriterBytes(w2))
 
     // Depth 1 — succeeds
@@ -2034,9 +2026,10 @@ class \nodoc\ _TestStreamDepthExact is UnitTest
     end
     MessagePackEncoder.uint(w, 42)
 
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_depth' = 5))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_depth' = 5))
     sd.append(_WriterBytes(w))
 
     // All 5 arrays should succeed
@@ -2044,8 +2037,8 @@ class \nodoc\ _TestStreamDepthExact is UnitTest
     while i < 5 do
       match sd.next()
       | let a: MessagePackArray => None
-      else h.fail("expected array at depth "
-        + (i + 1).string())
+      else h.fail("expected array at depth " +
+        (i + 1).string())
       end
       i = i + 1
     end
@@ -2066,9 +2059,10 @@ class \nodoc\ _TestStreamDepthExact is UnitTest
     end
     MessagePackEncoder.uint(w2, 42)
 
-    let sd2 = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_depth' = 5))
+    let sd2 =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_depth' = 5))
     sd2.append(_WriterBytes(w2))
 
     // First 5 succeed
@@ -2076,8 +2070,8 @@ class \nodoc\ _TestStreamDepthExact is UnitTest
     while i < 5 do
       match sd2.next()
       | let a: MessagePackArray => None
-      else h.fail("expected array at depth "
-        + (i + 1).string())
+      else h.fail("expected array at depth " +
+        (i + 1).string())
       end
       i = i + 1
     end
@@ -2103,8 +2097,9 @@ class \nodoc\ _TestStreamDepthAutoTrack is UnitTest
     MessagePackEncoder.uint(w, 2)
     MessagePackEncoder.uint(w, 3)
 
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits.unlimited())
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits.unlimited())
     sd.append(_WriterBytes(w))
 
     // Array(2) -> depth 1
@@ -2162,9 +2157,10 @@ class \nodoc\ _TestStreamDepthMap is UnitTest
     MessagePackEncoder.str(w, "b")?
     MessagePackEncoder.uint(w, 1)
 
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_depth' = 1))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_depth' = 1))
     sd.append(_WriterBytes(w))
 
     // Outer map at depth 1 — succeeds
@@ -2203,8 +2199,9 @@ class \nodoc\ _TestStreamDepthMixed is UnitTest
     MessagePackEncoder.fixarray(w, 1)?
     MessagePackEncoder.uint(w, 1)
 
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits.unlimited())
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits.unlimited())
     sd.append(_WriterBytes(w))
 
     // Array -> depth 1
@@ -2257,9 +2254,10 @@ class \nodoc\ _TestStreamDepthNoConsume is UnitTest
     MessagePackEncoder.fixarray(w, 1)?
     MessagePackEncoder.uint(w, 1)
 
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_depth' = 1))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_depth' = 1))
     sd.append(_WriterBytes(w))
 
     // Depth 1 — succeeds
@@ -2296,8 +2294,9 @@ class \nodoc\ _TestStreamDepthUnlimited is UnitTest
     end
     MessagePackEncoder.uint(w, 99)
 
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits.unlimited())
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits.unlimited())
     sd.append(_WriterBytes(w))
 
     // All 50 arrays should decode
@@ -2305,8 +2304,8 @@ class \nodoc\ _TestStreamDepthUnlimited is UnitTest
     while i < 50 do
       match sd.next()
       | let a: MessagePackArray => None
-      else h.fail("expected array at depth "
-        + (i + 1).string())
+      else h.fail("expected array at depth " +
+        (i + 1).string())
       end
       i = i + 1
     end
@@ -2330,9 +2329,10 @@ class \nodoc\ _TestStreamDepthZero is UnitTest
     let w: Writer ref = Writer
     MessagePackEncoder.uint(w, 42)
 
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_depth' = 0))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_depth' = 0))
     sd.append(_WriterBytes(w))
 
     // Scalar at depth 0 — works
@@ -2365,8 +2365,9 @@ class \nodoc\ _TestStreamDepthEmptyContainer is UnitTest
     MessagePackEncoder.fixarray(w, 0)?
     MessagePackEncoder.uint(w, 1)
 
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits.unlimited())
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits.unlimited())
     sd.append(_WriterBytes(w))
 
     // Outer array
@@ -2436,9 +2437,10 @@ class \nodoc\ _PropertyStreamDepth is Property1[U8]
     end
     MessagePackEncoder.uint(w, 42)
 
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_depth' = max_depth))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_depth' = max_depth))
     sd.append(_WriterBytes(w))
 
     if nesting > max_depth then
@@ -2448,8 +2450,8 @@ class \nodoc\ _PropertyStreamDepth is Property1[U8]
         match sd.next()
         | let a: MessagePackArray => None
         else
-          h.fail("expected array at depth "
-            + (i + 1).string())
+          h.fail("expected array at depth " +
+            (i + 1).string())
           return
         end
         i = i + 1
@@ -2458,9 +2460,9 @@ class \nodoc\ _PropertyStreamDepth is Property1[U8]
       match sd.next()
       | LimitExceeded => None
       else
-        h.fail("expected LimitExceeded at depth "
-          + (max_depth + 1).string()
-          + " with nesting " + nesting.string())
+        h.fail("expected LimitExceeded at depth " +
+          (max_depth + 1).string() +
+          " with nesting " + nesting.string())
       end
     else
       // All containers should decode
@@ -2469,8 +2471,8 @@ class \nodoc\ _PropertyStreamDepth is Property1[U8]
         match sd.next()
         | let a: MessagePackArray => None
         else
-          h.fail("expected array at depth "
-            + (i + 1).string())
+          h.fail("expected array at depth " +
+            (i + 1).string())
           return
         end
         i = i + 1
@@ -2490,7 +2492,6 @@ class \nodoc\ _PropertyStreamDepth is Property1[U8]
 //
 // Skip tests
 //
-
 class \nodoc\ _TestStreamSkipNil is UnitTest
   fun name(): String => "msgpack/StreamSkipNil"
 
@@ -2565,8 +2566,9 @@ class \nodoc\ _TestStreamSkipArray32 is UnitTest
         MessagePackEncoder.uint(w, 1)
         i = i + 1
       end
-      let sd = MessagePackStreamingDecoder(
-        MessagePackDecodeLimits.unlimited())
+      let sd =
+        MessagePackStreamingDecoder(
+          MessagePackDecodeLimits.unlimited())
       sd.append(_WriterBytes(w))
       match sd.skip()
       | None => None
@@ -2620,8 +2622,9 @@ class \nodoc\ _TestStreamSkipMap32 is UnitTest
         MessagePackEncoder.uint(w, 2)
         i = i + 1
       end
-      let sd = MessagePackStreamingDecoder(
-        MessagePackDecodeLimits.unlimited())
+      let sd =
+        MessagePackStreamingDecoder(
+          MessagePackDecodeLimits.unlimited())
       sd.append(_WriterBytes(w))
       match sd.skip()
       | None => None
@@ -2785,9 +2788,10 @@ class \nodoc\ _TestStreamSkipLimitExceeded is UnitTest
       i = i + 1
     end
 
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_skip_values' = 10))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_skip_values' = 10))
     sd.append(_WriterBytes(w))
 
     // 11 values to traverse, limit is 10
@@ -2811,9 +2815,10 @@ class \nodoc\ _TestStreamSkipLimitNoConsume is UnitTest
       i = i + 1
     end
 
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_skip_values' = 1))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_skip_values' = 1))
     sd.append(_WriterBytes(w))
 
     // First call: LimitExceeded
@@ -2993,7 +2998,6 @@ class \nodoc\ _TestStreamSkipInsideContainer is UnitTest
 //
 // Skip property-based tests
 //
-
 class \nodoc\ _PropertyStreamSkipU32Safety
   is Property1[U32]
   """
@@ -3020,8 +3024,8 @@ class \nodoc\ _PropertyStreamSkipU32Safety
       | NotEnoughData => None
       else
         h.fail(
-          "NotEnoughData expected at byte "
-            + i.string())
+          "NotEnoughData expected at byte " +
+            i.string())
         return
       end
       i = i + 1
@@ -3064,8 +3068,8 @@ class \nodoc\ _PropertyStreamSkipI16Safety
       | NotEnoughData => None
       else
         h.fail(
-          "NotEnoughData expected at byte "
-            + i.string())
+          "NotEnoughData expected at byte " +
+            i.string())
         return
       end
       i = i + 1
@@ -3110,8 +3114,8 @@ class \nodoc\ _PropertyStreamSkipStr8Safety
       | NotEnoughData => None
       else
         h.fail(
-          "NotEnoughData expected at byte "
-            + i.string())
+          "NotEnoughData expected at byte " +
+            i.string())
         return
       end
       i = i + 1
@@ -3162,8 +3166,8 @@ class \nodoc\ _PropertyStreamSkipFixext4Safety
       | NotEnoughData => None
       else
         h.fail(
-          "NotEnoughData expected at byte "
-            + i.string())
+          "NotEnoughData expected at byte " +
+            i.string())
         return
       end
       i = i + 1
@@ -3194,9 +3198,8 @@ class \nodoc\ _PropertyStreamSkipBin16Safety
     Generators.u8()
 
   fun ref property(arg1: U8, h: PropertyHelper) ? =>
-    let data = recover val
-      Array[U8].init('X', arg1.usize())
-    end
+    let data =
+      recover val Array[U8].init('X', arg1.usize()) end
     let w: Writer ref = Writer
     MessagePackEncoder.bin_16(w, data)?
     let bytes = _WriterBytes(w)
@@ -3210,8 +3213,8 @@ class \nodoc\ _PropertyStreamSkipBin16Safety
       | NotEnoughData => None
       else
         h.fail(
-          "NotEnoughData expected at byte "
-            + i.string())
+          "NotEnoughData expected at byte " +
+            i.string())
         return
       end
       i = i + 1
@@ -3253,9 +3256,10 @@ class \nodoc\ _PropertyStreamSkipLimitArray
       i = i + 1
     end
 
-    let sd = MessagePackStreamingDecoder(
-      MessagePackDecodeLimits(
-        where max_skip_values' = max_skip))
+    let sd =
+      MessagePackStreamingDecoder(
+        MessagePackDecodeLimits(
+          where max_skip_values' = max_skip))
     sd.append(_WriterBytes(w))
 
     // Total values traversed = count + 1 (the array itself)
@@ -3264,16 +3268,16 @@ class \nodoc\ _PropertyStreamSkipLimitArray
       | LimitExceeded => None
       else
         h.fail(
-          "expected LimitExceeded for count "
-            + count.string())
+          "expected LimitExceeded for count " +
+            count.string())
       end
     else
       match sd.skip()
       | None => None
       else
         h.fail(
-          "expected None for count "
-            + count.string())
+          "expected None for count " +
+            count.string())
       end
     end
 
@@ -3284,8 +3288,9 @@ class \nodoc\ _TestStreamDecodeFixstrUtf8 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.fixstr(w, "hello")?
-    let sd = MessagePackStreamingDecoder(
-      where validate_utf8' = true)
+    let sd =
+      MessagePackStreamingDecoder(
+        where validate_utf8' = true)
     sd.append(_WriterBytes(w))
     match sd.next()
     | let v: String val =>
@@ -3302,8 +3307,9 @@ class \nodoc\ _TestStreamDecodeFixstrUtf8Invalid
     let w: Writer ref = Writer
     let invalid = recover val [as U8: 0xFF; 0xFE] end
     MessagePackEncoder.fixstr(w, invalid)?
-    let sd = MessagePackStreamingDecoder(
-      where validate_utf8' = true)
+    let sd =
+      MessagePackStreamingDecoder(
+        where validate_utf8' = true)
     sd.append(_WriterBytes(w))
     match sd.next()
     | InvalidUtf8 => None
@@ -3317,8 +3323,9 @@ class \nodoc\ _TestStreamDecodeStr8Utf8 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.str_8(w, "hello")?
-    let sd = MessagePackStreamingDecoder(
-      where validate_utf8' = true)
+    let sd =
+      MessagePackStreamingDecoder(
+        where validate_utf8' = true)
     sd.append(_WriterBytes(w))
     match sd.next()
     | let v: String val =>
@@ -3335,8 +3342,9 @@ class \nodoc\ _TestStreamDecodeStr8Utf8Invalid
     let w: Writer ref = Writer
     let invalid = recover val [as U8: 0xFF; 0xFE] end
     MessagePackEncoder.str_8(w, invalid)?
-    let sd = MessagePackStreamingDecoder(
-      where validate_utf8' = true)
+    let sd =
+      MessagePackStreamingDecoder(
+        where validate_utf8' = true)
     sd.append(_WriterBytes(w))
     match sd.next()
     | InvalidUtf8 => None
@@ -3374,29 +3382,30 @@ class \nodoc\ _PropertyStreamStrUtf8Roundtrip
     "msgpack/PropertyStreamStrUtf8Roundtrip"
 
   fun gen(): Generator[String] =>
-    Generators.frequency[String]([
-      as WeightedGenerator[String]:
-      (5, Generators.ascii_printable(
-        0, _Limit.fixstr()))
-      (3, Generators.ascii_printable(
-        _Limit.fixstr() + 1,
-        U8.max_value().usize()))
-      (2, Generators.ascii_printable(
-        U8.max_value().usize() + 1, 300))
-    ])
+    Generators.frequency[String](
+      [ as WeightedGenerator[String]:
+        (5, Generators.ascii_printable(
+          0, _Limit.fixstr()))
+        (3, Generators.ascii_printable(
+          _Limit.fixstr() + 1,
+          U8.max_value().usize()))
+        (2, Generators.ascii_printable(
+          U8.max_value().usize() + 1, 300))
+      ])
 
   fun ref property(arg1: String, h: PropertyHelper) ? =>
     let s: String val = arg1.clone()
     let w: Writer ref = Writer
     MessagePackEncoder.str(w, s)?
-    let sd = MessagePackStreamingDecoder(
-      where validate_utf8' = true)
+    let sd =
+      MessagePackStreamingDecoder(
+        where validate_utf8' = true)
     sd.append(_WriterBytes(w))
     match sd.next()
     | let v: String val =>
       h.assert_eq[String](s, v)
     else
       h.fail(
-        "expected String for size "
-          + s.size().string())
+        "expected String for size " +
+          s.size().string())
     end

--- a/msgpack/_test_zero_copy_decoder.pony
+++ b/msgpack/_test_zero_copy_decoder.pony
@@ -1,21 +1,3 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 use "buffered"
 use "pony_check"
 use "pony_test"
@@ -27,16 +9,17 @@ primitive _ZeroCopyBytes
   """
   fun apply(w: Writer ref): ZeroCopyReader ref =>
     let b = ZeroCopyReader
-    let out = recover val
-      let a = Array[U8]
-      for chunk in w.done().values() do
-        match chunk
-        | let arr: Array[U8] val => a.append(arr)
-        | let s: String val => a.append(s.array())
+    let out =
+      recover val
+        let a = Array[U8]
+        for chunk in w.done().values() do
+          match \exhaustive\ chunk
+          | let arr: Array[U8] val => a.append(arr)
+          | let s: String val => a.append(s.array())
+          end
         end
+        a
       end
-      a
-    end
     b.append(out)
     b
 
@@ -167,7 +150,6 @@ actor \nodoc\ _TestZeroCopyDecoder is TestList
 //
 // ZeroCopyReader tests
 //
-
 class \nodoc\ _TestZCReaderBlockSingleChunk is UnitTest
   fun name(): String => "msgpack/ZCReaderBlockSingleChunk"
 
@@ -217,16 +199,17 @@ class \nodoc\ _TestZCReaderNumericReads is UnitTest
     w.f64_be(2.71828)
 
     let b = ZeroCopyReader
-    let out = recover val
-      let a = Array[U8]
-      for chunk in w.done().values() do
-        match chunk
-        | let arr: Array[U8] val => a.append(arr)
-        | let s: String val => a.append(s.array())
+    let out =
+      recover val
+        let a = Array[U8]
+        for chunk in w.done().values() do
+          match \exhaustive\ chunk
+          | let arr: Array[U8] val => a.append(arr)
+          | let s: String val => a.append(s.array())
+          end
         end
+        a
       end
-      a
-    end
     b.append(out)
 
     h.assert_eq[U8](42, b.u8()?)
@@ -304,7 +287,6 @@ class \nodoc\ _TestZCReaderExactBoundary is UnitTest
 //
 // Roundtrip tests
 //
-
 class \nodoc\ _TestZCDecodeNil is UnitTest
   fun name(): String => "msgpack/ZCDecodeNil"
 
@@ -339,7 +321,8 @@ class \nodoc\ _TestZCDecodeU8 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.uint_8(w, 9)
-    h.assert_eq[U8](9,
+    h.assert_eq[U8](
+      9,
       MessagePackZeroCopyDecoder.u8(
         _ZeroCopyBytes(w))?)
 
@@ -349,7 +332,8 @@ class \nodoc\ _TestZCDecodeU16 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.uint_16(w, 17)
-    h.assert_eq[U16](17,
+    h.assert_eq[U16](
+      17,
       MessagePackZeroCopyDecoder.u16(
         _ZeroCopyBytes(w))?)
 
@@ -359,7 +343,8 @@ class \nodoc\ _TestZCDecodeU32 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.uint_32(w, 33)
-    h.assert_eq[U32](33,
+    h.assert_eq[U32](
+      33,
       MessagePackZeroCopyDecoder.u32(
         _ZeroCopyBytes(w))?)
 
@@ -369,7 +354,8 @@ class \nodoc\ _TestZCDecodeU64 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.uint_64(w, 65)
-    h.assert_eq[U64](65,
+    h.assert_eq[U64](
+      65,
       MessagePackZeroCopyDecoder.u64(
         _ZeroCopyBytes(w))?)
 
@@ -379,7 +365,8 @@ class \nodoc\ _TestZCDecodeI8 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.int_8(w, 9)
-    h.assert_eq[I8](9,
+    h.assert_eq[I8](
+      9,
       MessagePackZeroCopyDecoder.i8(
         _ZeroCopyBytes(w))?)
 
@@ -389,7 +376,8 @@ class \nodoc\ _TestZCDecodeI16 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.int_16(w, 17)
-    h.assert_eq[I16](17,
+    h.assert_eq[I16](
+      17,
       MessagePackZeroCopyDecoder.i16(
         _ZeroCopyBytes(w))?)
 
@@ -399,7 +387,8 @@ class \nodoc\ _TestZCDecodeI32 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.int_32(w, 33)
-    h.assert_eq[I32](33,
+    h.assert_eq[I32](
+      33,
       MessagePackZeroCopyDecoder.i32(
         _ZeroCopyBytes(w))?)
 
@@ -409,7 +398,8 @@ class \nodoc\ _TestZCDecodeI64 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.int_64(w, 65)
-    h.assert_eq[I64](65,
+    h.assert_eq[I64](
+      65,
       MessagePackZeroCopyDecoder.i64(
         _ZeroCopyBytes(w))?)
 
@@ -420,7 +410,8 @@ class \nodoc\ _TestZCDecodePositiveFixint is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.positive_fixint(w, 17)?
-    h.assert_eq[U8](17,
+    h.assert_eq[U8](
+      17,
       MessagePackZeroCopyDecoder.positive_fixint(
         _ZeroCopyBytes(w))?)
 
@@ -431,7 +422,8 @@ class \nodoc\ _TestZCDecodeNegativeFixint is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.negative_fixint(w, -17)?
-    h.assert_eq[I8](-17,
+    h.assert_eq[I8](
+      -17,
       MessagePackZeroCopyDecoder.negative_fixint(
         _ZeroCopyBytes(w))?)
 
@@ -441,7 +433,8 @@ class \nodoc\ _TestZCDecodeF32 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.float_32(w, 33.33)
-    h.assert_eq[F32](33.33,
+    h.assert_eq[F32](
+      33.33,
       MessagePackZeroCopyDecoder.f32(
         _ZeroCopyBytes(w))?)
 
@@ -451,7 +444,8 @@ class \nodoc\ _TestZCDecodeF64 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.float_64(w, 65.65)
-    h.assert_eq[F64](65.65,
+    h.assert_eq[F64](
+      65.65,
       MessagePackZeroCopyDecoder.f64(
         _ZeroCopyBytes(w))?)
 
@@ -461,7 +455,8 @@ class \nodoc\ _TestZCDecodeFixstr is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.fixstr(w, "fixstr")?
-    h.assert_eq[String]("fixstr",
+    h.assert_eq[String](
+      "fixstr",
       MessagePackZeroCopyDecoder.fixstr(
         _ZeroCopyBytes(w))?)
 
@@ -471,7 +466,8 @@ class \nodoc\ _TestZCDecodeStr8 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.str_8(w, "str8")?
-    h.assert_eq[String]("str8",
+    h.assert_eq[String](
+      "str8",
       MessagePackZeroCopyDecoder.str_8(
         _ZeroCopyBytes(w))?)
 
@@ -481,7 +477,8 @@ class \nodoc\ _TestZCDecodeStr16 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.str_16(w, "str16")?
-    h.assert_eq[String]("str16",
+    h.assert_eq[String](
+      "str16",
       MessagePackZeroCopyDecoder.str_16(
         _ZeroCopyBytes(w))?)
 
@@ -491,7 +488,8 @@ class \nodoc\ _TestZCDecodeStr32 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.str_32(w, "str32")?
-    h.assert_eq[String]("str32",
+    h.assert_eq[String](
+      "str32",
       MessagePackZeroCopyDecoder.str_32(
         _ZeroCopyBytes(w))?)
 
@@ -543,7 +541,8 @@ class \nodoc\ _TestZCDecodeFixarray is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.fixarray(w, 8)?
-    h.assert_eq[U8](8,
+    h.assert_eq[U8](
+      8,
       MessagePackZeroCopyDecoder.fixarray(
         _ZeroCopyBytes(w))?)
 
@@ -553,7 +552,8 @@ class \nodoc\ _TestZCDecodeArray16 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.array_16(w, 17)
-    h.assert_eq[U16](17,
+    h.assert_eq[U16](
+      17,
       MessagePackZeroCopyDecoder.array_16(
         _ZeroCopyBytes(w))?)
 
@@ -563,7 +563,8 @@ class \nodoc\ _TestZCDecodeArray32 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.array_32(w, 33)
-    h.assert_eq[U32](33,
+    h.assert_eq[U32](
+      33,
       MessagePackZeroCopyDecoder.array_32(
         _ZeroCopyBytes(w))?)
 
@@ -573,7 +574,8 @@ class \nodoc\ _TestZCDecodeFixmap is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.fixmap(w, 8)?
-    h.assert_eq[U8](8,
+    h.assert_eq[U8](
+      8,
       MessagePackZeroCopyDecoder.fixmap(
         _ZeroCopyBytes(w))?)
 
@@ -583,7 +585,8 @@ class \nodoc\ _TestZCDecodeMap16 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.map_16(w, 17)
-    h.assert_eq[U16](17,
+    h.assert_eq[U16](
+      17,
       MessagePackZeroCopyDecoder.map_16(
         _ZeroCopyBytes(w))?)
 
@@ -593,7 +596,8 @@ class \nodoc\ _TestZCDecodeMap32 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.map_32(w, 33)
-    h.assert_eq[U32](33,
+    h.assert_eq[U32](
+      33,
       MessagePackZeroCopyDecoder.map_32(
         _ZeroCopyBytes(w))?)
 
@@ -602,7 +606,9 @@ class \nodoc\ _TestZCDecodeFixext1 is UnitTest
 
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
-    MessagePackEncoder.fixext_1(w, 7,
+    MessagePackEncoder.fixext_1(
+      w,
+      7,
       recover val [as U8: 0xAB] end)?
     (let t, let d) =
       MessagePackZeroCopyDecoder.fixext_1(
@@ -615,7 +621,9 @@ class \nodoc\ _TestZCDecodeFixext2 is UnitTest
 
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
-    MessagePackEncoder.fixext_2(w, 7,
+    MessagePackEncoder.fixext_2(
+      w,
+      7,
       recover val [as U8: 0xAB; 0xCD] end)?
     (let t, let d) =
       MessagePackZeroCopyDecoder.fixext_2(
@@ -628,7 +636,9 @@ class \nodoc\ _TestZCDecodeFixext4 is UnitTest
 
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
-    MessagePackEncoder.fixext_4(w, 7,
+    MessagePackEncoder.fixext_4(
+      w,
+      7,
       recover val [as U8: 1; 2; 3; 4] end)?
     (let t, let d) =
       MessagePackZeroCopyDecoder.fixext_4(
@@ -641,7 +651,9 @@ class \nodoc\ _TestZCDecodeFixext8 is UnitTest
 
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
-    MessagePackEncoder.fixext_8(w, 7,
+    MessagePackEncoder.fixext_8(
+      w,
+      7,
       recover val
         [as U8: 1; 2; 3; 4; 5; 6; 7; 8]
       end)?
@@ -656,15 +668,16 @@ class \nodoc\ _TestZCDecodeFixext16 is UnitTest
 
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
-    let data = recover val
-      let a = Array[U8]
-      var i: USize = 0
-      while i < 16 do
-        a.push(i.u8())
-        i = i + 1
+    let data =
+      recover val
+        let a = Array[U8]
+        var i: USize = 0
+        while i < 16 do
+          a.push(i.u8())
+          i = i + 1
+        end
+        a
       end
-      a
-    end
     MessagePackEncoder.fixext_16(w, 7, data)?
     (let t, let d) =
       MessagePackZeroCopyDecoder.fixext_16(
@@ -760,7 +773,8 @@ class \nodoc\ _TestZCDecodeCompactUint is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.uint(w, 42)
-    h.assert_eq[U64](42,
+    h.assert_eq[U64](
+      42,
       MessagePackZeroCopyDecoder.uint(
         _ZeroCopyBytes(w))?)
 
@@ -771,7 +785,8 @@ class \nodoc\ _TestZCDecodeCompactInt is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.int(w, -42)
-    h.assert_eq[I64](-42,
+    h.assert_eq[I64](
+      -42,
       MessagePackZeroCopyDecoder.int(
         _ZeroCopyBytes(w))?)
 
@@ -782,7 +797,8 @@ class \nodoc\ _TestZCDecodeCompactStr is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.str(w, "hello")?
-    h.assert_eq[String]("hello",
+    h.assert_eq[String](
+      "hello",
       MessagePackZeroCopyDecoder.str(
         _ZeroCopyBytes(w))?)
 
@@ -793,7 +809,8 @@ class \nodoc\ _TestZCDecodeCompactArray is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.array(w, 5)
-    h.assert_eq[U32](5,
+    h.assert_eq[U32](
+      5,
       MessagePackZeroCopyDecoder.array(
         _ZeroCopyBytes(w))?)
 
@@ -804,7 +821,8 @@ class \nodoc\ _TestZCDecodeCompactMap is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.map(w, 3)
-    h.assert_eq[U32](3,
+    h.assert_eq[U32](
+      3,
       MessagePackZeroCopyDecoder.map(
         _ZeroCopyBytes(w))?)
 
@@ -839,7 +857,6 @@ class \nodoc\ _TestZCDecodeCompactTimestamp is UnitTest
 //
 // Property-based roundtrip tests
 //
-
 class \nodoc\ _PropertyZCCompactUintRoundtrip
   is Property1[U64]
   fun name(): String =>
@@ -851,7 +868,8 @@ class \nodoc\ _PropertyZCCompactUintRoundtrip
   fun property(sample: U64, h: PropertyHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.uint(w, sample)
-    h.assert_eq[U64](sample,
+    h.assert_eq[U64](
+      sample,
       MessagePackZeroCopyDecoder.uint(
         _ZeroCopyBytes(w))?)
 
@@ -866,7 +884,8 @@ class \nodoc\ _PropertyZCCompactIntRoundtrip
   fun property(sample: I64, h: PropertyHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.int(w, sample)
-    h.assert_eq[I64](sample,
+    h.assert_eq[I64](
+      sample,
       MessagePackZeroCopyDecoder.int(
         _ZeroCopyBytes(w))?)
 
@@ -885,7 +904,8 @@ class \nodoc\ _PropertyZCCompactStrRoundtrip
   ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.str(w, sample)?
-    h.assert_eq[String](sample,
+    h.assert_eq[String](
+      sample,
       MessagePackZeroCopyDecoder.str(
         _ZeroCopyBytes(w))?)
 
@@ -900,7 +920,8 @@ class \nodoc\ _PropertyZCCompactArrayRoundtrip
   fun property(sample: U32, h: PropertyHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.array(w, sample)
-    h.assert_eq[U32](sample,
+    h.assert_eq[U32](
+      sample,
       MessagePackZeroCopyDecoder.array(
         _ZeroCopyBytes(w))?)
 
@@ -915,7 +936,8 @@ class \nodoc\ _PropertyZCCompactMapRoundtrip
   fun property(sample: U32, h: PropertyHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.map(w, sample)
-    h.assert_eq[U32](sample,
+    h.assert_eq[U32](
+      sample,
       MessagePackZeroCopyDecoder.map(
         _ZeroCopyBytes(w))?)
 
@@ -934,7 +956,8 @@ class \nodoc\ _PropertyZCStr8Roundtrip
   ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.str_8(w, sample)?
-    h.assert_eq[String](sample,
+    h.assert_eq[String](
+      sample,
       MessagePackZeroCopyDecoder.str_8(
         _ZeroCopyBytes(w))?)
 
@@ -953,7 +976,8 @@ class \nodoc\ _PropertyZCStr16Roundtrip
   ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.str_16(w, sample)?
-    h.assert_eq[String](sample,
+    h.assert_eq[String](
+      sample,
       MessagePackZeroCopyDecoder.str_16(
         _ZeroCopyBytes(w))?)
 
@@ -1218,11 +1242,11 @@ class \nodoc\ _PropertyZCExt16Roundtrip
       (U8, Array[U8] val)](
       Generators.u8()
         .filter({(v) => (v, v != 0xFF) }),
-      Generators.frequency[USize]([
-        as WeightedGenerator[USize]:
-        (7, Generators.usize(0, 300))
-        (3, Generators.usize(301, 1000))
-      ]),
+      Generators.frequency[USize](
+        [ as WeightedGenerator[USize]:
+          (7, Generators.usize(0, 300))
+          (3, Generators.usize(301, 1000))
+        ]),
       {(ext_type, len) =>
         (ext_type,
           recover val
@@ -1248,7 +1272,6 @@ class \nodoc\ _PropertyZCExt16Roundtrip
 //
 // Cross-decoder equivalence
 //
-
 class \nodoc\ _PropertyZCCrossDecoderStr
   is Property1[String]
   fun name(): String =>
@@ -1326,7 +1349,8 @@ class \nodoc\ _TestZCDecodeFixstrUtf8 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.fixstr(w, "fixstr")?
-    h.assert_eq[String]("fixstr",
+    h.assert_eq[String](
+      "fixstr",
       MessagePackZeroCopyDecoder.fixstr_utf8(
         _ZeroCopyBytes(w))?)
 
@@ -1350,7 +1374,8 @@ class \nodoc\ _TestZCDecodeStr8Utf8 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.str_8(w, "str8")?
-    h.assert_eq[String]("str8",
+    h.assert_eq[String](
+      "str8",
       MessagePackZeroCopyDecoder.str_8_utf8(
         _ZeroCopyBytes(w))?)
 
@@ -1374,7 +1399,8 @@ class \nodoc\ _TestZCDecodeStr16Utf8 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.str_16(w, "str16")?
-    h.assert_eq[String]("str16",
+    h.assert_eq[String](
+      "str16",
       MessagePackZeroCopyDecoder.str_16_utf8(
         _ZeroCopyBytes(w))?)
 
@@ -1398,7 +1424,8 @@ class \nodoc\ _TestZCDecodeStr32Utf8 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.str_32(w, "str32")?
-    h.assert_eq[String]("str32",
+    h.assert_eq[String](
+      "str32",
       MessagePackZeroCopyDecoder.str_32_utf8(
         _ZeroCopyBytes(w))?)
 
@@ -1423,7 +1450,8 @@ class \nodoc\ _TestZCDecodeCompactStrUtf8 is UnitTest
   fun ref apply(h: TestHelper) ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.str(w, "hello")?
-    h.assert_eq[String]("hello",
+    h.assert_eq[String](
+      "hello",
       MessagePackZeroCopyDecoder.str_utf8(
         _ZeroCopyBytes(w))?)
 
@@ -1457,7 +1485,8 @@ class \nodoc\ _PropertyZCCompactStrUtf8Roundtrip
   ? =>
     let w: Writer ref = Writer
     MessagePackEncoder.str_utf8(w, sample)?
-    h.assert_eq[String](sample,
+    h.assert_eq[String](
+      sample,
       MessagePackZeroCopyDecoder.str_utf8(
         _ZeroCopyBytes(w))?)
 

--- a/msgpack/_unreachable.pony
+++ b/msgpack/_unreachable.pony
@@ -1,21 +1,3 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 use @exit[None](status: U8)
 use @fprintf[I32](
   stream: Pointer[U8] tag,
@@ -31,10 +13,10 @@ primitive _Unreachable
   fun apply(loc: SourceLoc = __loc) =>
     @fprintf(
       @pony_os_stderr(),
-      ("The unreachable was reached in %s at line %s\n"
-        + "Please open an issue at "
-        + "https://github.com/ponylang/msgpack/"
-        + "issues")
+      ("The unreachable was reached in %s at line %s\n" +
+        "Please open an issue at " +
+        "https://github.com/ponylang/msgpack/" +
+        "issues")
         .cstring(),
       loc.file().cstring(),
       loc.line().string().cstring())

--- a/msgpack/message_pack_decode_limits.pony
+++ b/msgpack/message_pack_decode_limits.pony
@@ -1,21 +1,3 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 class val MessagePackDecodeLimits
   """
   Limits for the streaming decoder. Protects against
@@ -66,6 +48,9 @@ class val MessagePackDecodeLimits
     max_skip_values = max_skip_values'
 
   new val unlimited() =>
+    """
+    No size or depth limits. Suitable only for trusted input.
+    """
     max_str_len = USize.max_value()
     max_bin_len = USize.max_value()
     max_ext_len = USize.max_value()

--- a/msgpack/message_pack_decoder.pony
+++ b/msgpack/message_pack_decoder.pony
@@ -1,28 +1,12 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 use "buffered"
 
 type MessagePackType is U8
 
 primitive MessagePackDecoder
   """
-  Implements low-level decoding from the [MessagePack serialization format](https://github.com/msgpack/msgpack/blob/master/spec.md).
+  Implements low-level decoding from the
+  [MessagePack serialization format](
+  https://github.com/msgpack/msgpack/blob/master/spec.md).
 
   You should be familiar with how MessagePack encodes messages if you use
   this API directly. There are very few guardrails preventing you from
@@ -53,7 +37,6 @@ primitive MessagePackDecoder
   // The format-specific methods below remain available for callers
   // who know the exact wire format in advance.
   //
-
   fun uint(b: Reader ref): U64 ? =>
     """
     Decodes an unsigned integer from any uint or positive fixint
@@ -159,7 +142,6 @@ primitive MessagePackDecoder
   //
   // nil format family
   //
-
   fun nil(b: Reader ref): None ? =>
     """
     Returns nothing. Throws an error if the next byte isn't a MessagePack nil.
@@ -171,7 +153,6 @@ primitive MessagePackDecoder
   //
   // bool format family
   //
-
   fun bool(b: Reader ref): Bool ? =>
     match _read_type(b)?
     | _FormatName.truthy() => true
@@ -183,7 +164,6 @@ primitive MessagePackDecoder
   //
   // fixed number family
   //
-
   fun positive_fixint(b: Reader ref): U8 ? =>
     b.u8()?
 
@@ -193,7 +173,6 @@ primitive MessagePackDecoder
   //
   // unsigned int family
   //
-
   fun u8(b: Reader ref): U8 ? =>
     if _read_type(b)? != _FormatName.uint_8() then
       error
@@ -225,7 +204,6 @@ primitive MessagePackDecoder
   //
   // signed integer family
   //
-
   fun i8(b: Reader ref): I8 ? =>
     if _read_type(b)? != _FormatName.int_8() then
       error
@@ -257,7 +235,6 @@ primitive MessagePackDecoder
   //
   // float format family
   //
-
   fun f32(b: Reader ref): F32 ? =>
     if _read_type(b)? != _FormatName.float_32() then
       error
@@ -275,7 +252,6 @@ primitive MessagePackDecoder
   //
   // str family
   //
-
   // Note: MessagePackStreamingDecoder pre-validates total size
   // before calling this method. If the read sequence changes,
   // update the size check in _decode_fixstr.
@@ -286,17 +262,18 @@ primitive MessagePackDecoder
   fun str(b: Reader): String iso^ ? =>
     let t = _read_type(b)?
 
-    let len = if (t and 0xE0) == _FormatName.fixstr() then
-      (t and 0x1F).usize()
-    elseif t == _FormatName.str_8() then
-      b.u8()?
-    elseif t == _FormatName.str_16() then
-      b.u16_be()?.usize()
-    elseif t == _FormatName.str_32() then
-      b.u32_be()?.usize()
-    else
-      error
-    end
+    let len =
+      if (t and 0xE0) == _FormatName.fixstr() then
+        (t and 0x1F).usize()
+      elseif t == _FormatName.str_8() then
+        b.u8()?
+      elseif t == _FormatName.str_16() then
+        b.u16_be()?.usize()
+      elseif t == _FormatName.str_32() then
+        b.u32_be()?.usize()
+      else
+        error
+      end
 
     String.from_iso_array(b.block(len.usize())?)
 
@@ -354,7 +331,6 @@ primitive MessagePackDecoder
   //
   // str family — UTF-8 validating variants
   //
-
   fun str_utf8(b: Reader): String iso^ ? =>
     """
     Decodes a MessagePack str value using the smallest matching
@@ -426,19 +402,19 @@ primitive MessagePackDecoder
   //
   // byte array family
   //
-
   fun byte_array(b: Reader): Array[U8] iso^ ? =>
     let t = _read_type(b)?
 
-    let len = if t == _FormatName.bin_8() then
-      b.u8()?
-    elseif t == _FormatName.bin_16() then
-      b.u16_be()?.usize()
-    elseif t == _FormatName.bin_32() then
-      b.u32_be()?.usize()
-    else
-      error
-    end
+    let len =
+      if t == _FormatName.bin_8() then
+        b.u8()?
+      elseif t == _FormatName.bin_16() then
+        b.u16_be()?.usize()
+      elseif t == _FormatName.bin_32() then
+        b.u32_be()?.usize()
+      else
+        error
+      end
 
     b.block(len.usize())?
 
@@ -496,7 +472,6 @@ primitive MessagePackDecoder
   //
   // array format family
   //
-
   fun fixarray(b: Reader): U8 ? =>
     """
     Reads a header for a MessgePack "fixarray". This only reads the
@@ -532,7 +507,6 @@ primitive MessagePackDecoder
   //
   // map format family
   //
-
   fun fixmap(b: Reader): U8 ? =>
     """
     Reads a header for a MessgePack "fixmap". This only reads the
@@ -568,7 +542,6 @@ primitive MessagePackDecoder
   //
   // ext format family
   //
-
   fun ext(b: Reader): (U8, Array[U8] val) ? =>
     """
     Allows for the reading of user supplied extensions to the MessagePack
@@ -580,25 +553,26 @@ primitive MessagePackDecoder
     """
     let t = _read_type(b)?
 
-    let size: USize = if t == _FormatName.fixext_1() then
-      1
-    elseif t == _FormatName.fixext_2() then
-      2
-    elseif t == _FormatName.fixext_4() then
-      4
-    elseif t == _FormatName.fixext_8() then
-      8
-    elseif t == _FormatName.fixext_16() then
-      16
-    elseif t == _FormatName.ext_8() then
-      b.u8()?.usize()
-    elseif t == _FormatName.ext_16() then
-      b.u16_be()?.usize()
-    elseif t == _FormatName.ext_32() then
-      b.u32_be()?.usize()
-    else
-      error
-    end
+    let size: USize =
+      if t == _FormatName.fixext_1() then
+        1
+      elseif t == _FormatName.fixext_2() then
+        2
+      elseif t == _FormatName.fixext_4() then
+        4
+      elseif t == _FormatName.fixext_8() then
+        8
+      elseif t == _FormatName.fixext_16() then
+        16
+      elseif t == _FormatName.ext_8() then
+        b.u8()?.usize()
+      elseif t == _FormatName.ext_16() then
+        b.u16_be()?.usize()
+      elseif t == _FormatName.ext_32() then
+        b.u32_be()?.usize()
+      else
+        error
+      end
 
     (b.u8()?, b.block(size)?)
 
@@ -736,11 +710,15 @@ primitive MessagePackDecoder
   //
   // timestamp format family
   //
-
   // Note: MessagePackStreamingDecoder pre-validates total size
   // before calling this method. If the read sequence here changes,
   // update the size checks in _decode_fixext and _decode_ext_variable.
   fun timestamp(b: Reader): (I64, U32) ? =>
+    """
+    Decodes a MessagePack timestamp extension.
+
+    Returns a tuple of (seconds, nanoseconds).
+    """
     let t = _read_type(b)?
 
     b.i8()?
@@ -765,7 +743,6 @@ primitive MessagePackDecoder
   //
   // skip
   //
-
   fun skip(b: Reader ref) ? =>
     """
     Advances past one complete MessagePack value without
@@ -790,18 +767,18 @@ primitive MessagePackDecoder
         offset = offset + 1
       elseif fb <= 0x8F then
         // fixmap: 1 byte header, count * 2 values
-        remaining = remaining
-          + ((fb and 0x0F).usize() * 2)
+        remaining =
+          remaining + ((fb and 0x0F).usize() * 2)
         offset = offset + 1
       elseif fb <= 0x9F then
         // fixarray: 1 byte header, count values
-        remaining = remaining
-          + (fb and 0x0F).usize()
+        remaining =
+          remaining + (fb and 0x0F).usize()
         offset = offset + 1
       elseif fb <= 0xBF then
         // fixstr: 1 byte header + data
-        offset = offset + 1
-          + (fb and 0x1F).usize()
+        offset =
+          (offset + 1) + (fb and 0x1F).usize()
       elseif fb == _FormatName.nil() then
         offset = offset + 1
       elseif fb == 0xC1 then
@@ -893,25 +870,23 @@ primitive MessagePackDecoder
       elseif fb <= _FormatName.array_32() then
         // array_16/32
         if fb == _FormatName.array_16() then
-          remaining = remaining
-            + b.peek_u16_be(offset + 1)?.usize()
+          let c = b.peek_u16_be(offset + 1)?.usize()
+          remaining = remaining + c
           offset = offset + 3
         else
-          remaining = remaining
-            + b.peek_u32_be(offset + 1)?.usize()
+          let c = b.peek_u32_be(offset + 1)?.usize()
+          remaining = remaining + c
           offset = offset + 5
         end
       elseif fb <= _FormatName.map_32() then
         // map_16/32
         if fb == _FormatName.map_16() then
-          remaining = remaining
-            + (b.peek_u16_be(offset + 1)?.usize()
-              * 2)
+          let c = b.peek_u16_be(offset + 1)?.usize()
+          remaining = remaining + (c * 2)
           offset = offset + 3
         else
-          remaining = remaining
-            + (b.peek_u32_be(offset + 1)?.usize()
-              * 2)
+          let c = b.peek_u32_be(offset + 1)?.usize()
+          remaining = remaining + (c * 2)
           offset = offset + 5
         end
       else
@@ -924,6 +899,5 @@ primitive MessagePackDecoder
   //
   // support functions
   //
-
   fun _read_type(b: Reader ref): MessagePackType ? =>
     b.u8()?

--- a/msgpack/message_pack_encoder.pony
+++ b/msgpack/message_pack_encoder.pony
@@ -1,26 +1,10 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 use "buffered"
 
 primitive MessagePackEncoder
   """
-  Implements low-level encoding into the [MessagePack serialization format](https://github.com/msgpack/msgpack/blob/master/spec.md).
+  Implements low-level encoding into the
+  [MessagePack serialization format](
+  https://github.com/msgpack/msgpack/blob/master/spec.md).
 
   You should be familiar with how MessagePack encodes messages if you use
   this API directly. There are very few guardrails preventing you from
@@ -42,7 +26,6 @@ primitive MessagePackEncoder
   // The format-specific methods below remain available for callers
   // who want explicit control over the wire format.
   //
-
   fun uint(b: Writer, v: U64) =>
     """
     Encodes an unsigned integer using the smallest format that
@@ -171,12 +154,12 @@ primitive MessagePackEncoder
     if nsec > _Limit.nsec() then
       error
     end
-    if (nsec == 0) and (sec >= 0)
-      and (sec <= U32.max_value().i64())
+    if (nsec == 0) and (sec >= 0) and
+      (sec <= U32.max_value().i64())
     then
       timestamp_32(b, sec.u32())
-    elseif (sec >= 0)
-      and (sec.u64() <= _Limit.sec_34())
+    elseif (sec >= 0) and
+      (sec.u64() <= _Limit.sec_34())
     then
       timestamp_64(b, sec.u64(), nsec)?
     else
@@ -186,7 +169,6 @@ primitive MessagePackEncoder
   //
   // nil format family
   //
-
   fun nil(b: Writer) =>
     """
     nil format stores nil in 1 byte.
@@ -196,7 +178,6 @@ primitive MessagePackEncoder
   //
   // bool format family
   //
-
   fun bool(b: Writer, t_or_f: Bool) =>
     """
     bool format family stores false or true in 1 byte.
@@ -210,7 +191,6 @@ primitive MessagePackEncoder
   //
   // int format family
   //
-
   fun positive_fixint(b: Writer, v: U8) ? =>
     """
     positive fixnum stores 7-bit positive integer.
@@ -301,7 +281,6 @@ primitive MessagePackEncoder
   //
   // float format family
   //
-
   fun float_32(b: Writer, v: F32) =>
     """
     float 32 stores a floating point number in IEEE 754 single precision
@@ -321,7 +300,6 @@ primitive MessagePackEncoder
   //
   // str format family
   //
-
   fun fixstr(b: Writer, v: ByteSeq) ? =>
     """
     fixstr stores a byte array whose length is upto 31 bytes.
@@ -354,7 +332,7 @@ primitive MessagePackEncoder
     """
     _write_byte_array_16(b, v, _FormatName.str_16())?
 
-   fun str_32(b: Writer, v: ByteSeq) ? =>
+  fun str_32(b: Writer, v: ByteSeq) ? =>
     """
     str 32 stores a byte array whose length is upto (2^32)-1.
 
@@ -366,7 +344,6 @@ primitive MessagePackEncoder
   //
   // str format family — UTF-8 validating variants
   //
-
   fun str_utf8(b: Writer, v: ByteSeq) ? =>
     """
     Encodes a string using the smallest format that fits the
@@ -429,16 +406,16 @@ primitive MessagePackEncoder
     str_32(b, v)?
 
   fun _validate_utf8(v: ByteSeq) ? =>
-    let s = match v
-    | let s': String val => s'
-    | let a: Array[U8] val => String.from_array(a)
-    end
+    let s =
+      match \exhaustive\ v
+      | let s': String val => s'
+      | let a: Array[U8] val => String.from_array(a)
+      end
     if not MessagePackValidateUTF8(s) then error end
 
   //
   // bin format family
   //
-
   fun bin_8(b: Writer, v: ByteSeq) ? =>
     """
     bin 8 stores a byte array whose length is upto (2^8)-1 bytes.
@@ -457,19 +434,18 @@ primitive MessagePackEncoder
     """
     _write_byte_array_16(b, v, _FormatName.bin_16())?
 
-   fun bin_32(b: Writer, v: ByteSeq) ? =>
-     """
-     bin 32 stores a byte array whose length is upto (2^32)-1 bytes.
+  fun bin_32(b: Writer, v: ByteSeq) ? =>
+    """
+    bin 32 stores a byte array whose length is upto (2^32)-1 bytes.
 
-     Attempting to encode a `ByteSeq` larger than (2^32)-1 bytes will result in
-     an `error`.
-     """
+    Attempting to encode a `ByteSeq` larger than (2^32)-1 bytes will result in
+    an `error`.
+    """
     _write_byte_array_32(b, v, _FormatName.bin_32())?
 
   //
   // array format family
   //
-
   fun fixarray(b: Writer, s: U8) ? =>
     """
     Creates a header for a MessagePack "fixarray". This only creates the
@@ -517,7 +493,6 @@ primitive MessagePackEncoder
   //
   // map format family
   //
-
   fun fixmap(b: Writer, s: U8) ? =>
     """
     Creates a header for a MessagePack "fixmap". This only creates the
@@ -565,7 +540,6 @@ primitive MessagePackEncoder
   //
   // ext format family
   //
-
   fun fixext_1(b: Writer, t: U8, v: ByteSeq) ? =>
     """
     Allows for the creation of user supplied extensions to the MessagePack
@@ -759,7 +733,6 @@ primitive MessagePackEncoder
   //
   // timestamp format family
   //
-
   fun timestamp_32(b: Writer, sec: U32) =>
     """
     timestamp 32 stores the number of seconds that have elapsed since 1970-01-01
@@ -817,7 +790,6 @@ primitive MessagePackEncoder
   //
   // support methods
   //
-
   fun _write_type(b: Writer, t: U8) =>
     b.u8(t)
 

--- a/msgpack/message_pack_streaming_decoder.pony
+++ b/msgpack/message_pack_streaming_decoder.pony
@@ -1,21 +1,3 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 class MessagePackStreamingDecoder
   """
   A streaming-safe MessagePack decoder that never corrupts the
@@ -219,18 +201,18 @@ class MessagePackStreamingDecoder
         offset = offset + 1
       elseif fb <= 0x8F then
         // fixmap: 1 byte header, count * 2 values
-        remaining = remaining
-          + ((fb and 0x0F).usize() * 2)
+        remaining =
+          remaining + ((fb and 0x0F).usize() * 2)
         offset = offset + 1
       elseif fb <= 0x9F then
         // fixarray: 1 byte header, count values
-        remaining = remaining
-          + (fb and 0x0F).usize()
+        remaining =
+          remaining + (fb and 0x0F).usize()
         offset = offset + 1
       elseif fb <= 0xBF then
         // fixstr: 1 byte header + data
-        offset = offset + 1
-          + (fb and 0x1F).usize()
+        offset =
+          (offset + 1) + (fb and 0x1F).usize()
       elseif fb == 0xC0 then
         // nil: 1 byte
         offset = offset + 1
@@ -419,7 +401,6 @@ class MessagePackStreamingDecoder
   //
   // Fixed-size single-byte formats
   //
-
   fun ref _decode_positive_fixint(): DecodeResult =>
     // 0x00-0x7F: value is the byte itself
     try _reader.u8()?
@@ -457,7 +438,6 @@ class MessagePackStreamingDecoder
   //
   // Fixed-size numeric formats
   //
-
   fun ref _decode_float_32(): DecodeResult =>
     // 0xCA: 1 type + 4 data = 5 bytes
     if _reader.size() < 5 then return NotEnoughData end
@@ -537,7 +517,6 @@ class MessagePackStreamingDecoder
   //
   // Variable-length string formats
   //
-
   fun ref _decode_fixstr(fb: U8): DecodeResult =>
     // 0xA0-0xBF: 1 format byte + (fb AND fixstr mask) data bytes
     let data_len = fb.usize() and _Limit.fixstr()
@@ -549,8 +528,8 @@ class MessagePackStreamingDecoder
     end
     try
       let s = MessagePackZeroCopyDecoder.fixstr(_reader)?
-      if _validate_utf8
-        and not MessagePackValidateUTF8(s)
+      if _validate_utf8 and
+        not MessagePackValidateUTF8(s)
       then
         return InvalidUtf8
       end
@@ -596,15 +575,16 @@ class MessagePackStreamingDecoder
     end
 
     try
-      let s = if fb == _FormatName.str_8() then
-        MessagePackZeroCopyDecoder.str_8(_reader)?
-      elseif fb == _FormatName.str_16() then
-        MessagePackZeroCopyDecoder.str_16(_reader)?
-      else
-        MessagePackZeroCopyDecoder.str_32(_reader)?
-      end
-      if _validate_utf8
-        and not MessagePackValidateUTF8(s)
+      let s =
+        if fb == _FormatName.str_8() then
+          MessagePackZeroCopyDecoder.str_8(_reader)?
+        elseif fb == _FormatName.str_16() then
+          MessagePackZeroCopyDecoder.str_16(_reader)?
+        else
+          MessagePackZeroCopyDecoder.str_32(_reader)?
+        end
+      if _validate_utf8 and
+        not MessagePackValidateUTF8(s)
       then
         return InvalidUtf8
       end
@@ -617,7 +597,6 @@ class MessagePackStreamingDecoder
   //
   // Binary format
   //
-
   fun ref _decode_bin(fb: U8): DecodeResult =>
     // 0xC4: bin_8, header=2, len=peek_u8(1)
     // 0xC5: bin_16, header=3, len=peek_u16_be(1)
@@ -669,7 +648,6 @@ class MessagePackStreamingDecoder
   //
   // Array format
   //
-
   fun ref _decode_fixarray(fb: U8): DecodeResult =>
     // 0x90-0x9F: 1 byte header, count in low 4 bits
     let count = (fb and 0x0F).u32()
@@ -731,7 +709,6 @@ class MessagePackStreamingDecoder
   //
   // Map format
   //
-
   fun ref _decode_fixmap(fb: U8): DecodeResult =>
     // 0x80-0x8F: 1 byte header, count in low 4 bits
     let count = (fb and 0x0F).u32()
@@ -793,7 +770,6 @@ class MessagePackStreamingDecoder
   //
   // Fixed-size extension formats
   //
-
   fun ref _decode_fixext(fb: U8): DecodeResult =>
     // 0xD4: fixext_1, 3 bytes (1 type + 1 ext_type + 1 data)
     // 0xD5: fixext_2, 4 bytes
@@ -816,8 +792,8 @@ class MessagePackStreamingDecoder
     if _reader.size() < required then return NotEnoughData end
 
     // Timestamp: fixext_4 or fixext_8 with ext_type 0xFF
-    if (fb == _FormatName.fixext_4())
-      or (fb == _FormatName.fixext_8())
+    if (fb == _FormatName.fixext_4()) or
+      (fb == _FormatName.fixext_8())
     then
       try
         if _reader.peek_u8(1)? == 0xFF then
@@ -851,7 +827,6 @@ class MessagePackStreamingDecoder
   //
   // Variable-length extension formats
   //
-
   fun ref _decode_ext_variable(fb: U8): DecodeResult =>
     // 0xC7: ext_8, header=2 (1+1len), +1 type + data
     // 0xC8: ext_16, header=3 (1+2len), +1 type + data
@@ -919,7 +894,6 @@ class MessagePackStreamingDecoder
   //
   // Timestamp format
   //
-
   fun ref _decode_timestamp(): DecodeResult =>
     try
       (let sec, let nsec) = MessagePackZeroCopyDecoder.timestamp(_reader)?
@@ -932,7 +906,6 @@ class MessagePackStreamingDecoder
   //
   // Container depth tracking
   //
-
   fun ref _track(result: DecodeResult): DecodeResult =>
     match result
     | let a: MessagePackArray =>
@@ -965,8 +938,8 @@ class MessagePackStreamingDecoder
 
   fun ref _drain_completed() =>
     try
-      while (_stack.size() > 0)
-        and (_stack(_stack.size() - 1)? == 0)
+      while (_stack.size() > 0) and
+        (_stack(_stack.size() - 1)? == 0)
       do
         _stack.pop()?
       end

--- a/msgpack/message_pack_types.pony
+++ b/msgpack/message_pack_types.pony
@@ -1,21 +1,3 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 primitive NotEnoughData
   """
   Returned when the reader doesn't have enough data to decode the
@@ -97,32 +79,6 @@ class val MessagePackExt
     ext_type = ext_type'
     data = data'
 
-/*
-Union of all possible values returned by the streaming decoder.
-
-Multiple MessagePack wire formats collapse into the same Pony
-type. For example:
-
-* `positive_fixint` (1 byte) and `uint_8` (2 bytes) both
-  decode to `U8`.
-* `negative_fixint` (1 byte) and `int_8` (2 bytes) both
-  decode to `I8`.
-* `fixstr`, `str_8`, `str_16`, and `str_32` all decode to
-  `String val`.
-* `fixarray`, `array_16`, and `array_32` all decode to
-  `MessagePackArray`.
-* `fixmap`, `map_16`, and `map_32` all decode to
-  `MessagePackMap`.
-* `bin_8`, `bin_16`, and `bin_32` all decode to
-  `Array[U8] val`.
-* `fixext_1/2/4/8/16`, `ext_8`, `ext_16`, and `ext_32` all
-  decode to `MessagePackExt`.
-
-This is an intentional trade-off: a value-oriented API has no
-reason to preserve the encoding's size optimization choices.
-A caller seeing `U8(42)` cannot tell whether the encoder used
-the compact `positive_fixint` or the explicit `uint_8` format.
-*/
 type MessagePackValue is
   ( None
   | Bool

--- a/msgpack/message_pack_validate_utf8.pony
+++ b/msgpack/message_pack_validate_utf8.pony
@@ -1,21 +1,3 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 primitive MessagePackValidateUTF8
   """
   Validates whether a string contains only valid UTF-8 byte

--- a/msgpack/message_pack_zero_copy_decoder.pony
+++ b/msgpack/message_pack_zero_copy_decoder.pony
@@ -1,21 +1,3 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 primitive MessagePackZeroCopyDecoder
   """
   Implements low-level zero-copy decoding from the [MessagePack
@@ -52,7 +34,6 @@ primitive MessagePackZeroCopyDecoder
   //
   // compact format family
   //
-
   fun uint(b: ZeroCopyReader): U64 ? =>
     """
     Decodes an unsigned integer from any uint or positive fixint
@@ -158,7 +139,6 @@ primitive MessagePackZeroCopyDecoder
   //
   // nil format family
   //
-
   fun nil(b: ZeroCopyReader): None ? =>
     """
     Returns nothing. Throws an error if the next byte isn't a
@@ -171,7 +151,6 @@ primitive MessagePackZeroCopyDecoder
   //
   // bool format family
   //
-
   fun bool(b: ZeroCopyReader): Bool ? =>
     match _read_type(b)?
     | _FormatName.truthy() => true
@@ -183,7 +162,6 @@ primitive MessagePackZeroCopyDecoder
   //
   // fixed number family
   //
-
   fun positive_fixint(b: ZeroCopyReader): U8 ? =>
     b.u8()?
 
@@ -193,7 +171,6 @@ primitive MessagePackZeroCopyDecoder
   //
   // unsigned int family
   //
-
   fun u8(b: ZeroCopyReader): U8 ? =>
     if _read_type(b)? != _FormatName.uint_8() then
       error
@@ -225,7 +202,6 @@ primitive MessagePackZeroCopyDecoder
   //
   // signed integer family
   //
-
   fun i8(b: ZeroCopyReader): I8 ? =>
     if _read_type(b)? != _FormatName.int_8() then
       error
@@ -257,7 +233,6 @@ primitive MessagePackZeroCopyDecoder
   //
   // float format family
   //
-
   fun f32(b: ZeroCopyReader): F32 ? =>
     if _read_type(b)? != _FormatName.float_32() then
       error
@@ -275,7 +250,6 @@ primitive MessagePackZeroCopyDecoder
   //
   // str family
   //
-
   // Note: MessagePackStreamingDecoder pre-validates total size
   // before calling this method. If the read sequence changes,
   // update the size check in _decode_fixstr.
@@ -286,17 +260,18 @@ primitive MessagePackZeroCopyDecoder
   fun str(b: ZeroCopyReader): String val ? =>
     let t = _read_type(b)?
 
-    let len = if (t and 0xE0) == _FormatName.fixstr() then
-      (t and 0x1F).usize()
-    elseif t == _FormatName.str_8() then
-      b.u8()?
-    elseif t == _FormatName.str_16() then
-      b.u16_be()?.usize()
-    elseif t == _FormatName.str_32() then
-      b.u32_be()?.usize()
-    else
-      error
-    end
+    let len =
+      if (t and 0xE0) == _FormatName.fixstr() then
+        (t and 0x1F).usize()
+      elseif t == _FormatName.str_8() then
+        b.u8()?
+      elseif t == _FormatName.str_16() then
+        b.u16_be()?.usize()
+      elseif t == _FormatName.str_32() then
+        b.u32_be()?.usize()
+      else
+        error
+      end
 
     String.from_array(b.block(len.usize())?)
 
@@ -354,7 +329,6 @@ primitive MessagePackZeroCopyDecoder
   //
   // str family — UTF-8 validating variants
   //
-
   fun str_utf8(b: ZeroCopyReader): String val ? =>
     """
     Decodes a MessagePack str value using the smallest matching
@@ -427,19 +401,19 @@ primitive MessagePackZeroCopyDecoder
   //
   // byte array family
   //
-
   fun byte_array(b: ZeroCopyReader): Array[U8] val ? =>
     let t = _read_type(b)?
 
-    let len = if t == _FormatName.bin_8() then
-      b.u8()?
-    elseif t == _FormatName.bin_16() then
-      b.u16_be()?.usize()
-    elseif t == _FormatName.bin_32() then
-      b.u32_be()?.usize()
-    else
-      error
-    end
+    let len =
+      if t == _FormatName.bin_8() then
+        b.u8()?
+      elseif t == _FormatName.bin_16() then
+        b.u16_be()?.usize()
+      elseif t == _FormatName.bin_32() then
+        b.u32_be()?.usize()
+      else
+        error
+      end
 
     b.block(len.usize())?
 
@@ -497,7 +471,6 @@ primitive MessagePackZeroCopyDecoder
   //
   // array format family
   //
-
   fun fixarray(b: ZeroCopyReader): U8 ? =>
     """
     Reads a header for a MessgePack "fixarray". This only reads
@@ -533,7 +506,6 @@ primitive MessagePackZeroCopyDecoder
   //
   // map format family
   //
-
   fun fixmap(b: ZeroCopyReader): U8 ? =>
     """
     Reads a header for a MessgePack "fixmap". This only reads the
@@ -569,7 +541,6 @@ primitive MessagePackZeroCopyDecoder
   //
   // ext format family
   //
-
   fun ext(b: ZeroCopyReader): (U8, Array[U8] val) ? =>
     """
     Allows for the reading of user supplied extensions to the
@@ -581,25 +552,26 @@ primitive MessagePackZeroCopyDecoder
     """
     let t = _read_type(b)?
 
-    let size: USize = if t == _FormatName.fixext_1() then
-      1
-    elseif t == _FormatName.fixext_2() then
-      2
-    elseif t == _FormatName.fixext_4() then
-      4
-    elseif t == _FormatName.fixext_8() then
-      8
-    elseif t == _FormatName.fixext_16() then
-      16
-    elseif t == _FormatName.ext_8() then
-      b.u8()?.usize()
-    elseif t == _FormatName.ext_16() then
-      b.u16_be()?.usize()
-    elseif t == _FormatName.ext_32() then
-      b.u32_be()?.usize()
-    else
-      error
-    end
+    let size: USize =
+      if t == _FormatName.fixext_1() then
+        1
+      elseif t == _FormatName.fixext_2() then
+        2
+      elseif t == _FormatName.fixext_4() then
+        4
+      elseif t == _FormatName.fixext_8() then
+        8
+      elseif t == _FormatName.fixext_16() then
+        16
+      elseif t == _FormatName.ext_8() then
+        b.u8()?.usize()
+      elseif t == _FormatName.ext_16() then
+        b.u16_be()?.usize()
+      elseif t == _FormatName.ext_32() then
+        b.u32_be()?.usize()
+      else
+        error
+      end
 
     (b.u8()?, b.block(size)?)
 
@@ -737,12 +709,16 @@ primitive MessagePackZeroCopyDecoder
   //
   // timestamp format family
   //
-
   // Note: MessagePackStreamingDecoder pre-validates total size
   // before calling this method. If the read sequence here
   // changes, update the size checks in _decode_fixext and
   // _decode_ext_variable.
   fun timestamp(b: ZeroCopyReader): (I64, U32) ? =>
+    """
+    Decodes a MessagePack timestamp extension.
+
+    Returns a tuple of (seconds, nanoseconds).
+    """
     let t = _read_type(b)?
 
     b.i8()?
@@ -767,7 +743,6 @@ primitive MessagePackZeroCopyDecoder
   //
   // skip
   //
-
   fun skip(b: ZeroCopyReader ref) ? =>
     """
     Advances past one complete MessagePack value without
@@ -792,18 +767,18 @@ primitive MessagePackZeroCopyDecoder
         offset = offset + 1
       elseif fb <= 0x8F then
         // fixmap: 1 byte header, count * 2 values
-        remaining = remaining
-          + ((fb and 0x0F).usize() * 2)
+        remaining =
+          remaining + ((fb and 0x0F).usize() * 2)
         offset = offset + 1
       elseif fb <= 0x9F then
         // fixarray: 1 byte header, count values
-        remaining = remaining
-          + (fb and 0x0F).usize()
+        remaining =
+          remaining + (fb and 0x0F).usize()
         offset = offset + 1
       elseif fb <= 0xBF then
         // fixstr: 1 byte header + data
-        offset = offset + 1
-          + (fb and 0x1F).usize()
+        offset =
+          (offset + 1) + (fb and 0x1F).usize()
       elseif fb == _FormatName.nil() then
         offset = offset + 1
       elseif fb == 0xC1 then
@@ -895,25 +870,23 @@ primitive MessagePackZeroCopyDecoder
       elseif fb <= _FormatName.array_32() then
         // array_16/32
         if fb == _FormatName.array_16() then
-          remaining = remaining
-            + b.peek_u16_be(offset + 1)?.usize()
+          let c = b.peek_u16_be(offset + 1)?.usize()
+          remaining = remaining + c
           offset = offset + 3
         else
-          remaining = remaining
-            + b.peek_u32_be(offset + 1)?.usize()
+          let c = b.peek_u32_be(offset + 1)?.usize()
+          remaining = remaining + c
           offset = offset + 5
         end
       elseif fb <= _FormatName.map_32() then
         // map_16/32
         if fb == _FormatName.map_16() then
-          remaining = remaining
-            + (b.peek_u16_be(offset + 1)?.usize()
-              * 2)
+          let c = b.peek_u16_be(offset + 1)?.usize()
+          remaining = remaining + (c * 2)
           offset = offset + 3
         else
-          remaining = remaining
-            + (b.peek_u32_be(offset + 1)?.usize()
-              * 2)
+          let c = b.peek_u32_be(offset + 1)?.usize()
+          remaining = remaining + (c * 2)
           offset = offset + 5
         end
       else
@@ -926,6 +899,5 @@ primitive MessagePackZeroCopyDecoder
   //
   // support functions
   //
-
   fun _read_type(b: ZeroCopyReader): MessagePackType ? =>
     b.u8()?

--- a/msgpack/msgpack.pony
+++ b/msgpack/msgpack.pony
@@ -1,21 +1,3 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 """
 # Pony MessagePack
 

--- a/msgpack/zero_copy_reader.pony
+++ b/msgpack/zero_copy_reader.pony
@@ -1,21 +1,3 @@
-/*
-
-Copyright 2017 The Pony MessagePack Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
-
 class ZeroCopyReader
   """
   A reader optimized for zero-copy extraction of byte ranges.
@@ -56,7 +38,7 @@ class ZeroCopyReader
     the chunk's underlying array. No copy is performed.
     """
     let data_array =
-      match data
+      match \exhaustive\ data
       | let data': Array[U8] val => data'
       | let data': String => data'.array()
       end
@@ -338,11 +320,12 @@ class ZeroCopyReader
       let need = len - i
       let copy_len = need.min(avail)
 
-      out = recover iso
-        let r = consume ref out
-        data.copy_to(r, offset, i, copy_len)
-        consume r
-      end
+      out =
+        recover iso
+          let r = consume ref out
+          data.copy_to(r, offset, i, copy_len)
+          consume r
+        end
 
       if avail > need then
         _chunks(0)? = (data, offset + need)


### PR DESCRIPTION
The linting workflow was set up but the existing code wasn't passing it. This fixes every pony-lint error across all source and example files.

The bulk of the changes are mechanical formatting fixes: assignment-indent, operator-spacing, call-argument-format, array-literal-format, lambda-spacing, partial-spacing, blank-lines.

Non-formatting changes:
- Removed stale Apache 2.0 license headers from all source files (the project is BSD-2-Clause per LICENSE)
- Renamed example entry point files to `main.pony` (file-naming rule)
- Added package docstring files for each example directory (package-docstring rule)
- Added `\exhaustive\` annotations on match expressions that cover all union variants
- Added docstrings to public API elements that were missing them
