### PR TITLE
Update to work with ponyc 0.70.0

### DIFF
--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -17,7 +17,7 @@ jobs:
     name: Lint Pony source
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
     name: Test against recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test

--- a/.release-notes/update-to-ponyc-0.70.0.md
+++ b/.release-notes/update-to-ponyc-0.70.0.md
@@ -1,0 +1,3 @@
+## Update to work with ponyc 0.70.0
+
+Updated to use renamed PonyCheck generator range parameters (`from`/`to` instead of `min`/`max`).

--- a/msgpack/_test_zero_copy_decoder.pony
+++ b/msgpack/_test_zero_copy_decoder.pony
@@ -896,7 +896,7 @@ class \nodoc\ _PropertyZCCompactStrRoundtrip
 
   fun gen(): Generator[String] =>
     Generators.ascii(
-      where min = 0, max = 100)
+      where from = 0, to = 100)
 
   fun property(
     sample: String,
@@ -948,7 +948,7 @@ class \nodoc\ _PropertyZCStr8Roundtrip
 
   fun gen(): Generator[String] =>
     Generators.ascii(
-      where min = 0, max = 255)
+      where from = 0, to = 255)
 
   fun property(
     sample: String,
@@ -968,7 +968,7 @@ class \nodoc\ _PropertyZCStr16Roundtrip
 
   fun gen(): Generator[String] =>
     Generators.ascii(
-      where min = 0, max = 255)
+      where from = 0, to = 255)
 
   fun property(
     sample: String,
@@ -1279,7 +1279,7 @@ class \nodoc\ _PropertyZCCrossDecoderStr
 
   fun gen(): Generator[String] =>
     Generators.ascii(
-      where min = 0, max = 100)
+      where from = 0, to = 100)
 
   fun property(
     sample: String,
@@ -1477,7 +1477,7 @@ class \nodoc\ _PropertyZCCompactStrUtf8Roundtrip
 
   fun gen(): Generator[String] =>
     Generators.ascii(
-      where min = 0, max = 100)
+      where from = 0, to = 100)
 
   fun property(
     sample: String,
@@ -1497,7 +1497,7 @@ class \nodoc\ _PropertyZCCrossDecoderStrUtf8
 
   fun gen(): Generator[String] =>
     Generators.ascii(
-      where min = 0, max = 100)
+      where from = 0, to = 100)
 
   fun property(
     sample: String,


### PR DESCRIPTION
Updated to use renamed PonyCheck generator range parameters (`from`/`to` instead of `min`/`max`).
